### PR TITLE
Fix build script on mac.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,8 @@ module.exports = function(grunt) {
 
     htmlhint: {
       html1: {
-        src: ['src/html/index.html'
+        src: [
+          'src/app_engine/**/*.html'
         ]
       }
     },

--- a/build/build_app_engine_package.sh
+++ b/build/build_app_engine_package.sh
@@ -19,5 +19,6 @@ cp -r $SRC_DIR/app_engine/bigquery $DEST_DIR/
 cp -r $SRC_DIR/third_party $DEST_DIR/
 
 # Copy the python, .yaml, and html template files.
-find $SRC_DIR/app_engine -regex ".*\.\(py\|yaml\|html\)" -not -name '*test.py*' | xargs cp --target-directory=$DEST_DIR
-
+find $SRC_DIR/app_engine -iname "*.py" -not -iname '*test*.py*' | xargs -I {} cp {} $DEST_DIR/
+find $SRC_DIR/app_engine -iname "*.yaml" | xargs -I {} cp {} $DEST_DIR/
+find $SRC_DIR/app_engine -iname "*.html" | xargs -I {} cp {} $DEST_DIR/


### PR DESCRIPTION
The find/cp line used flags not present on mac. The single line command that works for mac (find -E $SRC_DIR/app_engine -regex ".*\.(py|yaml|html)" -not -name '*test.py*') doesn't work on linux.
