### PR TITLE
Add a 2h expiration time for static files

### DIFF
--- a/src/app_engine/app.yaml
+++ b/src/app_engine/app.yaml
@@ -3,6 +3,7 @@ version: 2
 runtime: python27
 threadsafe: true
 api_version: 1
+default_expiration: "2h"
 
 handlers:
 - url: /html


### PR DESCRIPTION
This is one of the issues found by PageSpeed Insights:

Leverage browser caching
Setting an expiry date or a maximum age in the HTTP headers for static resources instructs the browser to load previously downloaded resources from local disk rather than over the network.
Leverage browser caching for the following cacheable resources:
https://www.google-analytics.com/analytics.js (2 hours)