### PR TITLE
Rewriting python test provisioning from .sh to .py, separating travis and dev workflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - npm install
 
 script:
-  - grunt
+  - grunt travis

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,8 @@ module.exports = function(grunt) {
 
     shell: {
       runPythonTests: {
-        command: './build/run_python_tests.sh'
+        command: ['python', 'build/run_python_tests.py', 'google-appengine/',
+                  'out/app_engine/', 'webtest-master/'].join(' ')
       },
       buildAppEnginePackage: {
         command: 'python ./build/build_app_engine_package.py src ' + out_app_engine_dir,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,8 +56,14 @@ module.exports = function(grunt) {
     },
 
     shell: {
+      getPythonTestDeps: {
+        command: 'python build/get_python_test_deps.py'
+      },
+      getPythonTestDepsAndAutoInstall: {
+        command: 'python build/get_python_test_deps.py --auto-install-on-linux'
+      },
       runPythonTests: {
-        command: ['python', 'build/run_python_tests.py', 'google-appengine/',
+        command: ['python', 'build/run_python_tests.py', 'google_appengine/',
                   'out/app_engine/', 'webtest-master/'].join(' ')
       },
       buildAppEnginePackage: {
@@ -153,7 +159,7 @@ module.exports = function(grunt) {
     },
   });
 
-  // enable plugins
+  // Enable plugins.
   grunt.loadNpmTasks('grunt-contrib-csslint');
   grunt.loadNpmTasks('grunt-htmlhint');
   grunt.loadNpmTasks('grunt-jscs');
@@ -163,13 +169,13 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-closurecompiler');
   grunt.loadTasks('build/grunt-chrome-build');
 
-  // set default tasks to run when grunt is called without parameters
+  // Set default tasks to run when grunt is called without parameters.
   grunt.registerTask('default', ['csslint', 'htmlhint', 'jscs', 'jshint',
                                  'runPythonTests', 'jstests']);
-  grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackage', 'shell:runPythonTests']);
+  grunt.registerTask('travis', ['shell:getPythonTestDepsAndAutoInstall', 'default']);
+  grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackage', 'shell:getPythonTestDeps',
+                                        'shell:runPythonTests']);
   grunt.registerTask('jstests', ['closurecompiler:debug', 'jstdPhantom']);
-  // buildAppEnginePackage must be done before closurecompiler since buildAppEnginePackage resets the out/app_engine dir.
+  // buildAppEnginePackage must be done before closurecompiler since buildAppEnginePackage resets out/app_engine.
   grunt.registerTask('build', ['shell:buildAppEnginePackage', 'closurecompiler:debug', 'grunt-chrome-build']);
-  // also possible to call JavaScript directly in registerTask()
-  // or to call external tasks with grunt.loadTasks()
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,10 @@ module.exports = function(grunt) {
       buildAppEnginePackageWithTests: {
         command: ['python', './build/build_app_engine_package.py', 'src',
                   out_app_engine_dir, '--include-tests'].join(' ')
+      },
+      removePythonTestsFromOutAppEngineDir: {
+        command: ['python', './build/remove_python_tests.py',
+                  out_app_engine_dir].join(' ')
       }
     },
 
@@ -178,7 +182,8 @@ module.exports = function(grunt) {
                                 'default']);
   grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackageWithTests',
                                         'shell:getPythonTestDeps',
-                                        'shell:runPythonTests']);
+                                        'shell:runPythonTests',
+                                        'shell:removePythonTestsFromOutAppEngineDir']);
   grunt.registerTask('jstests', ['closurecompiler:debug', 'jstdPhantom']);
   // buildAppEnginePackage must be done before closurecompiler since buildAppEnginePackage resets out/app_engine.
   grunt.registerTask('build', ['shell:buildAppEnginePackage', 'closurecompiler:debug', 'grunt-chrome-build']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,8 +59,8 @@ module.exports = function(grunt) {
       getPythonTestDeps: {
         command: 'python build/get_python_test_deps.py'
       },
-      getPythonTestDepsAndAutoInstall: {
-        command: 'python build/get_python_test_deps.py --auto-install-on-linux'
+      installPythonTestDepsOnLinux: {
+        command: 'python build/install_webtest_on_linux.py webtest-master/'
       },
       runPythonTests: {
         command: ['python', 'build/run_python_tests.py', 'google_appengine/',
@@ -172,8 +172,11 @@ module.exports = function(grunt) {
   // Set default tasks to run when grunt is called without parameters.
   grunt.registerTask('default', ['csslint', 'htmlhint', 'jscs', 'jshint',
                                  'runPythonTests', 'jstests']);
-  grunt.registerTask('travis', ['shell:getPythonTestDepsAndAutoInstall', 'default']);
-  grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackage', 'shell:getPythonTestDeps',
+  grunt.registerTask('travis', ['shell:getPythonTestDeps',
+                                'shell:installPythonTestDepsOnLinux',
+                                'default']);
+  grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackage',
+                                        'shell:getPythonTestDeps',
                                         'shell:runPythonTests']);
   grunt.registerTask('jstests', ['closurecompiler:debug', 'jstdPhantom']);
   // buildAppEnginePackage must be done before closurecompiler since buildAppEnginePackage resets out/app_engine.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,14 +64,15 @@ module.exports = function(grunt) {
       },
       runPythonTests: {
         command: ['python', 'build/run_python_tests.py', 'google_appengine/',
-                  'out/app_engine/', 'webtest-master/'].join(' ')
+                  out_app_engine_dir, 'webtest-master/'].join(' ')
       },
       buildAppEnginePackage: {
-        command: 'python ./build/build_app_engine_package.py src ' + out_app_engine_dir,
-        options: {
-          stdout: true,
-          stderr: true
-        }
+        command: ['python', './build/build_app_engine_package.py', 'src',
+                  out_app_engine_dir].join(' ')
+      },
+      buildAppEnginePackageWithTests: {
+        command: ['python', './build/build_app_engine_package.py', 'src',
+                  out_app_engine_dir, '--include-tests'].join(' ')
       }
     },
 
@@ -175,7 +176,7 @@ module.exports = function(grunt) {
   grunt.registerTask('travis', ['shell:getPythonTestDeps',
                                 'shell:installPythonTestDepsOnLinux',
                                 'default']);
-  grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackage',
+  grunt.registerTask('runPythonTests', ['shell:buildAppEnginePackageWithTests',
                                         'shell:getPythonTestDeps',
                                         'shell:runPythonTests']);
   grunt.registerTask('jstests', ['closurecompiler:debug', 'jstdPhantom']);

--- a/build/build_app_engine_package.py
+++ b/build/build_app_engine_package.py
@@ -57,7 +57,7 @@ def build_version_info_file(dest_path):
     print str(e)
 
 
-def main(src_path, dest_path):
+def CopyApprtcSource(src_path, dest_path):
   if os.path.exists(dest_path):
     shutil.rmtree(dest_path)
   os.makedirs(dest_path)
@@ -80,7 +80,8 @@ def main(src_path, dest_path):
           shutil.copy(os.path.join(dirpath, name), dest_html_path)
     elif dirpath.endswith('app_engine'):
       for name in files:
-        if (name.endswith('.py') or name.endswith('.yaml')):
+        if (name.endswith('.py') and 'test' not in name
+            or name.endswith('.yaml')):
           shutil.copy(os.path.join(dirpath, name), dest_path)
     elif dirpath.endswith('js'):
       for name in files:
@@ -94,11 +95,28 @@ def main(src_path, dest_path):
 
   build_version_info_file(os.path.join(dest_path, 'version_info.json'))
 
-if __name__ == '__main__':
+
+def CopyTests(src_path, dest_path):
+  for dirpath, _, files in os.walk(src_path):
+    if dirpath.endswith('app_engine'):
+      tests = [name for name in files if 'test' in name]
+      for test in tests:
+        shutil.copy(os.path.join(dirpath, test), dest_path)
+
+
+def main():
   parser = optparse.OptionParser(USAGE)
-  _, args = parser.parse_args()
+  parser.add_option("-t", "--include-tests", action="store_true",
+                    help='Also copy python tests to the out dir.')
+  options, args = parser.parse_args()
   if len(args) != 2:
     parser.error('Error: Exactly 2 arguments required.')
 
   src_path, dest_path = args[0:2]
-  main(src_path, dest_path)
+  CopyApprtcSource(src_path, dest_path)
+  if options.include_tests:
+    CopyTests(src_path, dest_path)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/build_app_engine_package.py
+++ b/build/build_app_engine_package.py
@@ -10,6 +10,8 @@ import shutil
 import subprocess
 import sys
 
+import test_file_herder
+
 USAGE = """%prog src_path dest_path
 Build the GAE source code package.
 
@@ -96,14 +98,6 @@ def CopyApprtcSource(src_path, dest_path):
   build_version_info_file(os.path.join(dest_path, 'version_info.json'))
 
 
-def CopyTests(src_path, dest_path):
-  for dirpath, _, files in os.walk(src_path):
-    if dirpath.endswith('app_engine'):
-      tests = [name for name in files if 'test' in name]
-      for test in tests:
-        shutil.copy(os.path.join(dirpath, test), dest_path)
-
-
 def main():
   parser = optparse.OptionParser(USAGE)
   parser.add_option("-t", "--include-tests", action="store_true",
@@ -115,7 +109,8 @@ def main():
   src_path, dest_path = args[0:2]
   CopyApprtcSource(src_path, dest_path)
   if options.include_tests:
-    CopyTests(src_path, dest_path)
+    app_engine_code = os.path.join(src_path, 'app_engine')
+    test_file_herder.CopyTests(os.path.join(src_path, 'app_engine'), dest_path)
 
 
 if __name__ == '__main__':

--- a/build/build_app_engine_package.py
+++ b/build/build_app_engine_package.py
@@ -80,8 +80,7 @@ def main(src_path, dest_path):
           shutil.copy(os.path.join(dirpath, name), dest_html_path)
     elif dirpath.endswith('app_engine'):
       for name in files:
-        if (name.endswith('.py') and name.find('test') == -1 or
-            name.endswith('.yaml')):
+        if (name.endswith('.py') or name.endswith('.yaml')):
           shutil.copy(os.path.join(dirpath, name), dest_path)
     elif dirpath.endswith('js'):
       for name in files:

--- a/build/build_app_engine_package.py
+++ b/build/build_app_engine_package.py
@@ -10,11 +10,11 @@ import shutil
 import subprocess
 import sys
 
-USAGE = """%prog SRC_PATH DEST_PATH
+USAGE = """%prog src_path dest_path
 Build the GAE source code package.
 
-SRC_PATH     Path to the source code root directory.
-DEST_PATH    Path to the root directory to push/deploy GAE from."""
+src_path     Path to the source code root directory.
+dest_path    Path to the root directory to push/deploy GAE from."""
 
 
 def call_cmd_and_return_output_lines(cmd):
@@ -96,12 +96,9 @@ def main(src_path, dest_path):
 
 if __name__ == '__main__':
   parser = optparse.OptionParser(USAGE)
-  options, args = parser.parse_args()
+  _, args = parser.parse_args()
   if len(args) != 2:
-    print 'Error: Exactly 2 arguments required.'
-    parser.print_help()
-    sys.exit(1)
+    parser.error('Error: Exactly 2 arguments required.')
 
-  SRC_PATH = args[0]
-  DEST_PATH = args[1]
-  main(SRC_PATH, DEST_PATH)
+  src_path, dest_path = args[0:2]
+  main(src_path, dest_path)

--- a/build/get_python_test_dependencies.py
+++ b/build/get_python_test_dependencies.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+
+import optparse
+import os
+import re
+import sys
+import tarfile
+import urllib2
+import zipfile
+
+
+GAE_DOWNLOAD_URL = 'https://storage.googleapis.com/appengine-sdks/featured/'
+GAE_UPDATECHECK_URL = 'https://appengine.google.com/api/updatecheck'
+WEBTEST_URL = 'https://nodeload.github.com/Pylons/webtest/tar.gz/master'
+
+
+def _GetLatestAppEngineSdkVersion():
+  response = urllib2.urlopen(GAE_UPDATECHECK_URL)
+  response_text = response.read()
+
+  match = re.search('(\d*\.\d*\.\d*)', response_text)
+  if not match:
+    raise Exception('Could not determine latest GAE SDK version from '
+                    'response %s.' % response_text)
+  gae_sdk_version = match.group(1)
+  if gae_sdk_version == '1.9.15':
+    # TODO(phoglund): remove when updatecheck returns the right thing.
+    gae_sdk_version = '1.9.17'
+  return gae_sdk_version
+
+
+def _Download(url, to):
+  print 'Downloading %s to %s...' % (url, to)
+  response = urllib2.urlopen(url)
+  with open(to, 'w') as to_file:
+    to_file.write(response.read())
+
+
+def _Unzip(path):
+  print 'Unzipping %s in %s...' % (path, os.getcwd())
+  zip_file = zipfile.ZipFile(path)
+  try:
+    zip_file.extractall()
+  finally:
+    zip_file.close()
+
+
+def _Untar(path):
+  print 'Untarring %s in %s...' % (path, os.getcwd())
+  tar_file = tarfile.open(path, 'r:gz')
+  try:
+    tar_file.extractall()
+  finally:
+    tar_file.close()
+
+
+def DownloadAppEngineSdkIfNecessary():
+  gae_sdk_version = _GetLatestAppEngineSdkVersion()
+  gae_sdk_file = 'google_appengine_%s.zip' % gae_sdk_version
+  _Download(GAE_DOWNLOAD_URL + gae_sdk_file, gae_sdk_file)
+  _Unzip(gae_sdk_file)
+
+
+def _InstallWebTestOnLinux(webtest_dir):
+  cwd = os.getcwd()
+  try:
+    print 'About to install webtest into your system python.'
+    print 'Enter your password if you agree.'
+    os.chdir(webtest_dir)
+    os.system('sudo python setup.py install')
+  finally:
+    os.chdir(cwd)
+
+
+def DownloadWebTestIfNecessary():
+  webtest_file = 'webtest-master.tar.gz'
+  _Download(WEBTEST_URL, webtest_file)
+  _Untar(webtest_file)
+
+
+def _EnsureWebTestIsInstalled():
+  try:
+    import webtest
+    return 0
+  except ImportError:
+    print 'You need to install webtest before you can proceed running the '
+    print 'tests. To do this you need to get easy_install. See '
+    print 'https://pythonhosted.org/setuptools/easy_install.html'
+    print 'Then:'
+    print 'cd webtest-master'
+    print 'sudo python setup.py install'
+    return 1
+
+
+def main():
+  usage = 'usage: %prog [options]'
+  parser = optparse.OptionParser(usage)
+  parser.add_option('-a', '--auto-install-on-linux', action='store_true',
+                    help=('Attempt to install dependencies automatically '
+                          '(i.e. Travis mode). Only supported on Linux.'))
+  options, _ = parser.parse_args()
+  DownloadAppEngineSdkIfNecessary()
+  DownloadWebTestIfNecessary()
+  if options.auto_install_on_linux:
+    _InstallWebTestOnLinux('webtest-master')
+  
+  return _EnsureWebTestIsInstalled()
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/get_python_test_dependencies.py
+++ b/build/get_python_test_dependencies.py
@@ -78,20 +78,6 @@ def DownloadWebTestIfNecessary():
   _Untar(webtest_file)
 
 
-def _EnsureWebTestIsInstalled():
-  try:
-    import webtest
-    return 0
-  except ImportError:
-    print 'You need to install webtest before you can proceed running the '
-    print 'tests. To do this you need to get easy_install. See '
-    print 'https://pythonhosted.org/setuptools/easy_install.html'
-    print 'Then:'
-    print 'cd webtest-master'
-    print 'sudo python setup.py install'
-    return 1
-
-
 def main():
   usage = 'usage: %prog [options]'
   parser = optparse.OptionParser(usage)
@@ -104,7 +90,5 @@ def main():
   if options.auto_install_on_linux:
     _InstallWebTestOnLinux('webtest-master')
   
-  return _EnsureWebTestIsInstalled()
-
 if __name__ == '__main__':
   sys.exit(main())

--- a/build/get_python_test_deps.py
+++ b/build/get_python_test_deps.py
@@ -61,21 +61,25 @@ def DownloadAppEngineSdkIfNecessary():
   _Unzip(gae_sdk_file)
 
 
-def _InstallWebTestOnLinux(webtest_dir):
-  cwd = os.getcwd()
-  try:
-    print 'About to install webtest into your system python.'
-    print 'Enter your password if you agree.'
-    os.chdir(webtest_dir)
-    os.system('sudo python setup.py install')
-  finally:
-    os.chdir(cwd)
-
-
 def DownloadWebTestIfNecessary():
   webtest_file = 'webtest-master.tar.gz'
   _Download(WEBTEST_URL, webtest_file)
   _Untar(webtest_file)
+
+
+def _InstallWebTestOnLinux(webtest_dir):
+  cwd = os.getcwd()
+  try:
+    print 'About to install webtest into your system python.'
+    os.chdir(webtest_dir)
+    result = os.system('sudo python setup.py install')
+    if result == 0:
+      print 'Install successful.'
+    else:
+      return ('Failed to install webtest; are you missing setuptools / '
+              'easy_install in your system python?')
+  finally:
+    os.chdir(cwd)
 
 
 def main():
@@ -88,7 +92,7 @@ def main():
   DownloadAppEngineSdkIfNecessary()
   DownloadWebTestIfNecessary()
   if options.auto_install_on_linux:
-    _InstallWebTestOnLinux('webtest-master')
+    return _InstallWebTestOnLinux('webtest-master')
   
 if __name__ == '__main__':
   sys.exit(main())

--- a/build/get_python_test_deps.py
+++ b/build/get_python_test_deps.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import optparse
 import os
 import re
 import sys
@@ -57,42 +56,27 @@ def _Untar(path):
 def DownloadAppEngineSdkIfNecessary():
   gae_sdk_version = _GetLatestAppEngineSdkVersion()
   gae_sdk_file = 'google_appengine_%s.zip' % gae_sdk_version
+  if os.path.exists(gae_sdk_file):
+    print 'Already has %s, skipping' % gae_sdk_file
+    return
+
   _Download(GAE_DOWNLOAD_URL + gae_sdk_file, gae_sdk_file)
   _Unzip(gae_sdk_file)
 
 
 def DownloadWebTestIfNecessary():
   webtest_file = 'webtest-master.tar.gz'
+  if os.path.exists(webtest_file):
+    print 'Already has %s, skipping' % webtest_file
+    return
+
   _Download(WEBTEST_URL, webtest_file)
   _Untar(webtest_file)
 
 
-def _InstallWebTestOnLinux(webtest_dir):
-  cwd = os.getcwd()
-  try:
-    print 'About to install webtest into your system python.'
-    os.chdir(webtest_dir)
-    result = os.system('sudo python setup.py install')
-    if result == 0:
-      print 'Install successful.'
-    else:
-      return ('Failed to install webtest; are you missing setuptools / '
-              'easy_install in your system python?')
-  finally:
-    os.chdir(cwd)
-
-
 def main():
-  usage = 'usage: %prog [options]'
-  parser = optparse.OptionParser(usage)
-  parser.add_option('-a', '--auto-install-on-linux', action='store_true',
-                    help=('Attempt to install dependencies automatically '
-                          '(i.e. Travis mode). Only supported on Linux.'))
-  options, _ = parser.parse_args()
   DownloadAppEngineSdkIfNecessary()
   DownloadWebTestIfNecessary()
-  if options.auto_install_on_linux:
-    return _InstallWebTestOnLinux('webtest-master')
   
 if __name__ == '__main__':
   sys.exit(main())

--- a/build/install_webtest_on_linux.py
+++ b/build/install_webtest_on_linux.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+import optparse
+import os
+import sys
+
+
+def InstallWebTestOnLinux(webtest_dir):
+  cwd = os.getcwd()
+  try:
+    print 'About to install webtest into your system python.'
+    os.chdir(webtest_dir)
+    result = os.system('sudo python setup.py install')
+    if result == 0:
+      print 'Install successful.'
+    else:
+      return ('Failed to install webtest; are you missing setuptools / '
+              'easy_install in your system python?')
+  finally:
+    os.chdir(cwd)
+
+
+def main():
+  parser = optparse.OptionParser('Usage: %prog webtest_path')
+  _, args = parser.parse_args()
+  if len(args) != 1:
+    parser.error('Expected precisely one argument.')
+  return InstallWebTestOnLinux(args[0])
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/remove_python_tests.py
+++ b/build/remove_python_tests.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+
+import optparse
+import sys
+
+import test_file_herder
+
+
+def main():
+  parser = optparse.OptionParser('Usage: %prog path_to_tests')
+  _, args = parser.parse_args()
+  if len(args) != 1:
+    parser.error('Expected precisely one argument.')
+
+  return test_file_herder.RemoveTests(args[0])
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/run_python_tests.py
+++ b/build/run_python_tests.py
@@ -13,11 +13,27 @@ TEST_PATH    Path to package containing test modules.
 WEBTEST_PATH Path to the webtest library."""
 
 
+def _WebTestIsInstalled():
+  try:
+    import webtest
+    return True
+  except ImportError:
+    print 'You need to install webtest before you can proceed running the '
+    print 'tests. To do this you need to get easy_install. See '
+    print 'https://pythonhosted.org/setuptools/easy_install.html'
+    print 'Then:'
+    print 'cd webtest-master'
+    print 'sudo python setup.py install'
+    return False
+
+
 def main(sdk_path, test_path, webtest_path):
     sys.path.insert(0, sdk_path)
     import dev_appserver
     dev_appserver.fix_sys_path()
     sys.path.append(webtest_path)
+    if not _WebTestIsInstalled():
+      return False
     suite = unittest.loader.TestLoader().discover(test_path,
                                                   pattern="*test.py")
     return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()

--- a/build/run_python_tests.py
+++ b/build/run_python_tests.py
@@ -5,12 +5,12 @@ import optparse
 import sys
 import unittest
 
-USAGE = """%prog SDK_PATH TEST_PATH
+USAGE = """%prog sdk_path test_path webtest_path
 Run unit tests for App Engine apps.
 
-SDK_PATH     Path to the SDK installation.
-TEST_PATH    Path to package containing test modules.
-WEBTEST_PATH Path to the webtest library."""
+sdk_path     Path to the SDK installation.
+test_path    Path to package containing test modules.
+webtest_path Path to the webtest library."""
 
 
 def _WebTestIsInstalled():
@@ -53,8 +53,7 @@ if __name__ == '__main__':
   parser = optparse.OptionParser(USAGE)
   options, args = parser.parse_args()
   if len(args) != 3:
-    print 'Error: Exactly 3 arguments required.'
-    parser.print_help()
-    sys.exit(1)
+    parser.error('Error: Exactly 3 arguments required.')
+
   sdk_path, test_path, webtest_path = args[0:3]
   sys.exit(main(sdk_path, test_path, webtest_path))

--- a/build/run_python_tests.py
+++ b/build/run_python_tests.py
@@ -18,35 +18,43 @@ def _WebTestIsInstalled():
     import webtest
     return True
   except ImportError:
-    print 'You need to install webtest before you can proceed running the '
-    print 'tests. To do this you need to get easy_install. See '
-    print 'https://pythonhosted.org/setuptools/easy_install.html'
+    print 'You need to install webtest dependencies before you can proceed '
+    print 'running the tests. To do this you need to get easy_install since '
+    print 'that is how webtest provisions its dependencies.'
+    print 'See https://pythonhosted.org/setuptools/easy_install.html.'
     print 'Then:'
     print 'cd webtest-master'
-    print 'sudo python setup.py install'
+    print 'python setup.py install'
+    print '(Prefix with sudo / run in admin shell as necessary).'
     return False
 
 
 def main(sdk_path, test_path, webtest_path):
-    sys.path.insert(0, sdk_path)
-    import dev_appserver
-    dev_appserver.fix_sys_path()
-    sys.path.append(webtest_path)
-    if not _WebTestIsInstalled():
-      return False
-    suite = unittest.loader.TestLoader().discover(test_path,
-                                                  pattern="*test.py")
-    return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
+  if not os.path.exists(sdk_path):
+    return 'Missing %s: try grunt shell:getPythonTestDeps.' % sdk_path
+  if not os.path.exists(test_path):
+    return 'Missing %s: try grunt build.' % test_path
+  if not os.path.exists(webtest_path):
+    return 'Missing %s: try grunt shell:getPythonTestDeps.' % webtest_path
+
+  sys.path.insert(0, sdk_path)
+  import dev_appserver
+  dev_appserver.fix_sys_path()
+  sys.path.append(webtest_path)
+  if not _WebTestIsInstalled():
+    return 1
+  suite = unittest.loader.TestLoader().discover(test_path,
+                                                pattern="*test.py")
+  ok = unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
+  return 0 if ok else 1
 
 
 if __name__ == '__main__':
-    parser = optparse.OptionParser(USAGE)
-    options, args = parser.parse_args()
-    if len(args) != 3:
-        print 'Error: Exactly 3 arguments required.'
-        parser.print_help()
-        sys.exit(1)
-    SDK_PATH = args[0]
-    TEST_PATH = args[1]
-    WEBTEST_PATH = args[2]
-    sys.exit(not main(SDK_PATH, TEST_PATH, WEBTEST_PATH))
+  parser = optparse.OptionParser(USAGE)
+  options, args = parser.parse_args()
+  if len(args) != 3:
+    print 'Error: Exactly 3 arguments required.'
+    parser.print_help()
+    sys.exit(1)
+  sdk_path, test_path, webtest_path = args[0:3]
+  sys.exit(main(sdk_path, test_path, webtest_path))

--- a/build/test_file_herder.py
+++ b/build/test_file_herder.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+"""Copies and deletes tests."""
+
+import os
+import shutil
+
+
+def _IsPythonTest(filename):
+  return 'test' in filename and filename.endswith('.py')
+
+
+def CopyTests(src_path, dest_path):
+  if not os.path.exists(src_path):
+    raise Exception('Failed to copy tests from %s; does not exist.' % src_path)
+
+  for dirpath, _, files in os.walk(src_path):
+    tests = [name for name in files if _IsPythonTest(name)]
+    for test in tests:
+      shutil.copy(os.path.join(dirpath, test), dest_path)
+
+
+def RemoveTests(path):
+  if not os.path.exists(path):
+    raise Exception('Failed to remove tests from %s; does not exist.' % path)
+
+  for dirpath, _, files in os.walk(path):
+    tests = [name for name in files if _IsPythonTest(name)]
+    for test in tests:
+      to_remove = os.path.join(dirpath, test)
+      print 'Removing %s.' % to_remove
+      os.remove(to_remove)


### PR DESCRIPTION
This patch gets rid of the .sh file we used to download dependencies for the python tests. This should now work on Windows.

Furthermore, I try to improve the confusing setup around webtests. The script will no longer attempt to autoinstall webtest since it requires easy_install - it now tells the developer what to do and exits cleanly. I could have made the script download and install easy_install, but I don't like running sudo on the developer's behalf. Adding more of that seems wrong.

Travis will still need to run sudo and it already has easy_install/setuptools, so I create a new workflow for Travis where this is done automatically.