### PR TITLE
Factor out Google API auth.

### DIFF
--- a/src/app_engine/apiauth.py
+++ b/src/app_engine/apiauth.py
@@ -1,0 +1,38 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+
+"""Google API auth utilities."""
+
+import json
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'third_party'))
+
+from apiclient import discovery
+import httplib2
+import oauth2client.appengine
+import oauth2client.client
+
+import constants
+
+
+def build(scope, service_name, version):
+  """Build a service object if authorization is available."""
+  credentials = None
+  if constants.IS_DEV_SERVER:
+    # Local instances require a 'secrets.json' file.
+    secrets_path = os.path.join(os.path.dirname(__file__), 'secrets.json')
+    if os.path.exists(secrets_path):
+      with open(secrets_path) as f:
+        auth = json.load(f)
+        credentials = oauth2client.client.SignedJwtAssertionCredentials(
+            auth['client_email'], auth['private_key'], scope)
+  else:
+    # Use the GAE service credentials.
+    credentials = oauth2client.appengine.AppAssertionCredentials(scope=scope)
+
+  if credentials is None:
+    return None
+
+  http = credentials.authorize(httplib2.Http())
+  return discovery.build(service_name, version, http=http)

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python2.4
-#
-# Copyright 2014 Google Inc. All Rights Reserved.
+# Copyright 2015 Google Inc. All Rights Reserved.
 
-"""AppRTC Constants
+"""AppRTC Constants.
 
 This module contains the constants used in AppRTC Python modules.
 """
@@ -26,23 +24,27 @@ RESPONSE_UNKNOWN_CLIENT = 'UNKNOWN_CLIENT'
 RESPONSE_DUPLICATE_CLIENT = 'DUPLICATE_CLIENT'
 RESPONSE_SUCCESS = 'SUCCESS'
 
-BIGQUERY_URL='https://www.googleapis.com/auth/bigquery'
+IS_DEV_SERVER = os.environ.get('APPLICATION_ID', '').startswith('dev')
+
+BIGQUERY_URL = 'https://www.googleapis.com/auth/bigquery'
 
 # Dataset used in production.
-BIGQUERY_DATASET_PROD='prod'
+BIGQUERY_DATASET_PROD = 'prod'
 
 # Dataset used when running locally.
-BIGQUERY_DATASET_LOCAL='dev'
+BIGQUERY_DATASET_LOCAL = 'dev'
 
 # BigQuery table within the dataset.
-BIGQUERY_TABLE='analytics'
+BIGQUERY_TABLE = 'analytics'
 
-class EventType:
+
+class EventType(object):
   # Event signifying that a room enters the state of having exactly
   # two participants.
-  ROOM_SIZE_2='room_size_2'
+  ROOM_SIZE_2 = 'room_size_2'
 
-class LogField:
+
+class LogField(object):
   pass
 
 with open(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
This takes the portion of the analytics code we use to create an
authorized API object and puts it in a shared googleapi module. We can
then use this later for any cloud API.