### PR TITLE
Compute engine handle page.

### DIFF
--- a/src/app_engine/app.yaml
+++ b/src/app_engine/app.yaml
@@ -18,6 +18,10 @@ handlers:
 - url: /css
   static_dir: css
 
+- url: /compute/.*
+  script: apprtc.app
+  login: admin
+
 - url: /probe.*
   script: probers.app
   secure: always

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -21,6 +21,7 @@ from google.appengine.api import urlfetch
 
 import analytics
 import analytics_page
+import compute_page
 import constants
 
 jinja_environment = jinja2.Environment(
@@ -552,6 +553,7 @@ class ParamsPage(webapp2.RequestHandler):
 app = webapp2.WSGIApplication([
     ('/', MainPage),
     ('/a/', analytics_page.AnalyticsPage),
+    ('/compute/(\w+)/(\S+)/(\S+)', compute_page.ComputePage),
     ('/join/(\w+)', JoinPage),
     ('/leave/(\w+)/(\w+)', LeavePage),
     ('/message/(\w+)/(\w+)', MessagePage),

--- a/src/app_engine/compute_page.py
+++ b/src/app_engine/compute_page.py
@@ -1,0 +1,104 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+
+"""Compute page for handling tasks related to compute engine."""
+
+import logging
+
+import webapp2
+
+import apiauth
+from google.appengine.api import app_identity
+from google.appengine.api import taskqueue
+
+
+# Page actions
+# Get the status of an instance.
+ACTION_STATUS = 'status'
+
+# Start the compute instance if it is not already started. When an
+# instance is in the TERMINATED state, it will be started. If the
+# instance is already RUNNING do nothing. If the instance is in an
+# intermediate state--PROVISIONING, STAGING, STOPPING--the task is
+# requeued.
+ACTION_START = 'start'
+
+# Constants for the Compute Engine API
+COMPUTE_STATUS = 'status'
+COMPUTE_STATUS_TERMINATED = 'TERMINATED'
+COMPUTE_STATUS_RUNNING = 'RUNNING'
+
+# Seconds between API retries.
+TASK_RETRY_S = 3
+
+COMPUTE_API_URL = 'https://www.googleapis.com/auth/compute'
+
+
+class ComputePage(webapp2.RequestHandler):
+  """Page to handle requests against GCE."""
+
+  def __init__(self, request, response):
+    # Call initialize rather than the parent constructor fun. See:
+    # https://webapp-improved.appspot.com/guide/handlers.html#overriding-init
+    self.initialize(request, response)
+
+    self.compute_service = self._build_compute_service()
+    if self.compute_service is None:
+      logging.warning('Unable to create Compute service object.')
+
+  def _build_compute_service(self):
+    return apiauth.build(scope=COMPUTE_API_URL,
+                         service_name='compute',
+                         version='v1')
+
+  def _enqueue_start_task(self, instance, zone):
+    taskqueue.add(url='/compute/start/%s/%s' % (instance, zone),
+                  countdown=TASK_RETRY_S)
+
+  def _maybe_start_instance(self, instance, zone):
+    """Implementation for start action.
+
+    Args:
+      instance: Name of the instance to start.
+      zone: Name of the zone the instance belongs to.
+
+    """
+    if self.compute_service is None:
+      logging.warning('Unable to start Compute instance, service unavailable.')
+      return
+
+    status = self._compute_status(instance, zone)
+
+    logging.info('GCE VM \'%s (%s)\' status: \'%s\'.',
+                 instance, zone, status)
+
+    if status == COMPUTE_STATUS_TERMINATED:
+      logging.info('Starting GCE VM: %s (%s)', instance, zone)
+      self.compute_service.instances().start(
+          project=app_identity.get_application_id(),
+          instance=instance,
+          zone=zone).execute()
+    elif status != COMPUTE_STATUS_RUNNING:
+      # Instance is in an intermediate state: PROVISIONING, STAGING,
+      # STOPPING. Thus, requeue the task.
+      self._enqueue_start_task(instance, zone)
+
+  def _compute_status(self, instance, zone):
+    """Return the status of the compute instance."""
+    if self.compute_service is None:
+      logging.warning('Service unavailable: unable to start GCE VM: %s (%s)',
+                      instance, zone)
+      return
+
+    info = self.compute_service.instances().get(
+        project=app_identity.get_application_id(),
+        instance=instance,
+        zone=zone).execute()
+    return info[COMPUTE_STATUS]
+
+  def get(self, action, instance, zone):
+    if action == ACTION_STATUS:
+      self.response.write(self._compute_status(instance, zone))
+
+  def post(self, action, instance, zone):
+    if action == ACTION_START:
+      self._maybe_start_instance(instance, zone)

--- a/src/app_engine/compute_page_test.py
+++ b/src/app_engine/compute_page_test.py
@@ -1,0 +1,179 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+
+import unittest
+import webtest
+
+import apprtc
+import compute_page
+from test_util import CapturingFunction
+from test_util import ReplaceFunction
+
+from google.appengine.ext import testbed
+
+
+class FakeComputeService(object):
+  """Handles Compute Engine service calls to the Google API client."""
+
+  def __init__(self):
+    # This is a bit hacky but the Google API is lots of function
+    # chaining. This at least makes things easier to reason about as
+    # opposed to making a new variable for each level.
+    self.instances = CapturingFunction(lambda: self.instances)
+
+    self.instances.start = CapturingFunction(lambda: self.instances.start)
+    self.instances.start.execute = CapturingFunction()
+
+    # Change the status of an instance by setting the return value.
+    self.get_return_value = None
+    self.instances.get = CapturingFunction(lambda: self.instances.get)
+    self.instances.get.execute = CapturingFunction(
+        lambda: self.get_return_value)
+
+
+class ComputePageHandlerTest(unittest.TestCase):
+  def setUp(self):
+    # First, create an instance of the Testbed class.
+    self.testbed = testbed.Testbed()
+
+    # Then activate the testbed, which prepares the service stubs for use.
+    self.testbed.activate()
+
+    # Next, declare which service stubs you want to use.
+    self.testbed.init_taskqueue_stub()
+
+    self.test_app = webtest.TestApp(apprtc.app)
+
+    # Fake out the compute service.
+    self.build_compute_service_replacement = ReplaceFunction(
+        compute_page.ComputePage,
+        '_build_compute_service',
+        self.fake_build_compute_service)
+
+    # Note that '_build_compute_service' is called at request
+    # time. Tests need to be able to setup test data in the fake
+    # before ComputePage is initialize. Thus compute_service is
+    # created here and it is assumed that _build_compute_service is
+    # only called once.
+    self.compute_service = FakeComputeService()
+
+    # Default testbed app name.
+    self.app_id = 'testbed-test'
+
+  def fake_build_compute_service(self, *args):
+    return self.compute_service
+
+  def tearDown(self):
+    self.testbed.deactivate()
+    del self.build_compute_service_replacement
+
+  # TODO(decurtis): Extract these functions to our own test base class.
+  def makePostRequest(self, path, body=''):
+    return self.test_app.post(path, body, headers={'User-Agent': 'Safari'})
+
+  def makeGetRequest(self, path):
+    # PhantomJS uses WebKit, so Safari is closest to the thruth.
+    return self.test_app.get(path, headers={'User-Agent': 'Safari'})
+
+  def testGetStatus(self):
+    instance = 'test-instance'
+    zone = 'test-zone'
+
+    # Fake instance has status of RUNNING
+    instance_status = compute_page.COMPUTE_STATUS_RUNNING
+    self.compute_service.get_return_value = {
+        compute_page.COMPUTE_STATUS: instance_status
+    }
+
+    response = self.makeGetRequest('/compute/%s/%s/%s' %
+                                   (compute_page.ACTION_STATUS, instance, zone))
+
+    get_dict = {'project': self.app_id,
+                'instance': instance,
+                'zone': zone}
+
+    actual_get_dict = self.compute_service.instances.get.last_kwargs
+    self.assertEqual(get_dict, actual_get_dict)
+    self.assertEqual(instance_status, response.body)
+
+  def testPostStartWhenTerminated(self):
+    """Test start action with instance in the TERMINATED state."""
+    instance = 'test-instance'
+    zone = 'test-zone'
+    start_url = '/compute/%s/%s/%s' % (compute_page.ACTION_START,
+                                       instance, zone)
+
+    # Suppose that instance is TERMINATED.
+    instance_status = compute_page.COMPUTE_STATUS_TERMINATED
+    self.compute_service.get_return_value = {
+        compute_page.COMPUTE_STATUS: instance_status
+    }
+
+    # makePostRequest will check for 200 success.
+    self.makePostRequest(start_url)
+
+    # If the state is TERMINATED then we should not have a new start
+    # task.
+    tasks = self.testbed.get_stub('taskqueue').GetTasks('default')
+    self.assertEqual(0, len(tasks))
+
+    # Verify start() API called only once.
+    self.assertEqual(1, self.compute_service.instances.start.num_calls)
+
+    # Check start() API called when in the TERMINATED state.
+    get_dict = {'project': self.app_id,
+                'instance': instance,
+                'zone': zone}
+    actual_get_dict = self.compute_service.instances.start.last_kwargs
+    self.assertEqual(get_dict, actual_get_dict)
+
+  def testPostStartWhenRunning(self):
+    """Test start action when instance in the RUNNING state."""
+    instance = 'test-instance'
+    zone = 'test-zone'
+    start_url = '/compute/%s/%s/%s' % (compute_page.ACTION_START,
+                                       instance, zone)
+
+    instance_status = compute_page.COMPUTE_STATUS_RUNNING
+    self.compute_service.get_return_value = {
+        compute_page.COMPUTE_STATUS: instance_status
+    }
+
+    self.makePostRequest(start_url)
+
+    # No further tasks needed.
+    tasks = self.testbed.get_stub('taskqueue').GetTasks('default')
+    self.assertEqual(0, len(tasks))
+
+    # Verify start() API not called.
+    self.assertEqual(0, self.compute_service.instances.start.num_calls)
+
+  def testPostStartNotRunningOrTerminated(self):
+    """Test start action in an intermediate state."""
+    compute_instances = self.compute_service.instances
+    taskqueue = self.testbed.get_stub('taskqueue')
+
+    instance = 'test-instance'
+    zone = 'test-zone'
+    start_url = '/compute/%s/%s/%s' % (compute_page.ACTION_START,
+                                       instance, zone)
+
+    # Check all intermediate states.
+    for instance_status in ['PROVISIONING', 'STAGING', 'STOPPING']:
+      self.compute_service.get_return_value = {
+          compute_page.COMPUTE_STATUS: instance_status
+      }
+
+      self.makePostRequest(start_url)
+
+      # Since if the instance neither RUNNING nor TERMINATED then a
+      # new task should be queued.
+      tasks = taskqueue.GetTasks('default')
+      self.assertEqual(1, len(tasks))
+      task = tasks[-1]
+      self.assertEqual(start_url, task['url'])
+
+      # Verify start() API not called.
+      self.assertEqual(0, self.compute_service.instances.start.num_calls)
+
+      # Simulate the start task running AGAIN but instance is RUNNING.
+      taskqueue.FlushQueue('default')

--- a/src/app_engine/test_util.py
+++ b/src/app_engine/test_util.py
@@ -20,6 +20,7 @@ class CapturingFunction(object):
   """Captures the last arguments called on a function."""
 
   def __init__(self, return_value=None):
+    self.num_calls = 0
     self.return_value = return_value
     self.last_args = None
     self.last_kwargs = None
@@ -27,6 +28,7 @@ class CapturingFunction(object):
   def __call__(self, *args, **kwargs):
     self.last_args = args
     self.last_kwargs = kwargs
+    self.num_calls += 1
 
     if callable(self.return_value):
       return self.return_value()


### PR DESCRIPTION
Adds a page that can be used to start the compute instances programmatically.


@jiayliu  :: *Need to add unit tests but wanted to get your take on this idea when you get time.*