### PR TITLE
Remove error log from Collider status report

### DIFF
--- a/src/collider/collider/dashboard_test.go
+++ b/src/collider/collider/dashboard_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"log"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -80,17 +79,11 @@ func TestDashboardWsErr(t *testing.T) {
 	if r.WsErrs != 0 {
 		t.Errorf("db.getReport().WsErrs is %d, want 0", r.WsErrs)
 	}
-	if len(r.ErrLog) != 0 {
-		t.Errorf("len(db.getReport().ErrLog) is %d, want 0", len(r.ErrLog))
-	}
 
 	db.onWsErr(errors.New("Fake error"))
 	r = db.getReport(rt)
 	if r.WsErrs != 1 {
 		t.Errorf("db.getReport().WsErrs is %d, want 1", r.WsErrs)
-	}
-	if len(r.ErrLog) != 1 {
-		t.Errorf("len(db.getReport().ErrLog) is %d, want 1", len(r.ErrLog))
 	}
 }
 
@@ -101,43 +94,9 @@ func TestDashboardHttpErr(t *testing.T) {
 	if r.HttpErrs != 0 {
 		t.Errorf("db.getReport().HttpErrs is %d, want 0", r.HttpErrs)
 	}
-	if len(r.ErrLog) != 0 {
-		t.Errorf("len(db.getReport().ErrLog) is %d, want 0", len(r.ErrLog))
-	}
-
 	db.onHttpErr(errors.New("Fake error"))
 	r = db.getReport(rt)
 	if r.HttpErrs != 1 {
 		t.Errorf("db.getReport().HttpErrs is %d, want 1", r.HttpErrs)
-	}
-	if len(r.ErrLog) != 1 {
-		t.Errorf("len(db.getReport().ErrLog) is %d, want 1", len(r.ErrLog))
-	}
-}
-
-func TestDashboardErrLog(t *testing.T) {
-	rt := createNewRoomTable()
-	db := newDashboard()
-
-	for i := 0; i < maxErrLogLen+1; i++ {
-		db.onHttpErr(errors.New(strconv.Itoa(i)))
-	}
-	r := db.getReport(rt)
-
-	if r.HttpErrs != maxErrLogLen+1 {
-		t.Errorf("db.getReport().HttpErrs is %d, want %d", r.HttpErrs, maxErrLogLen+1)
-	}
-	if len(r.ErrLog) != maxErrLogLen {
-		t.Errorf("len(db.getReport().ErrLog) is %d, want %d", len(r.ErrLog), maxErrLogLen)
-	}
-
-	// Verifies the start and the end of the error log.
-	expected_err := "1"
-	if r.ErrLog[0].Err != expected_err {
-		t.Errorf("The first error in db.getReport().ErrLog is %s, want %s", r.ErrLog[0].Err, expected_err)
-	}
-	expected_err = strconv.Itoa(maxErrLogLen)
-	if r.ErrLog[maxErrLogLen-1].Err != expected_err {
-		t.Errorf("The last error in db.getReport().ErrLog is %s, want %s", r.ErrLog[maxErrLogLen-1].Err, expected_err)
 	}
 }


### PR DESCRIPTION
The error message may contain IP address and should not be made public.