### PR TITLE
Move EventType LogField to the analytics module.

### DIFF
--- a/src/app_engine/analytics.py
+++ b/src/app_engine/analytics.py
@@ -3,6 +3,7 @@
 """Module for pushing analytics data to BigQuery."""
 
 import datetime
+import json
 import logging
 import os
 import sys
@@ -12,9 +13,23 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'third_party'))
 
 import apiauth
 import constants
-from constants import LogField
 
 from google.appengine.api import app_identity
+
+class EventType(object):
+  # Event signifying that a room enters the state of having exactly
+  # two participants.
+  ROOM_SIZE_2 = 'room_size_2'
+  ICE_CONNECTION_STATE_CONNECTED = 'ice_connection_state_connected'
+
+class LogField(object):
+  pass
+
+with open(os.path.join(os.path.dirname(__file__),
+                       'bigquery', 'analytics_schema.json')) as f:
+  schema = json.load(f)
+  for field in schema:
+    setattr(LogField, field['name'].upper(), field['name'])
 
 
 class Analytics(object):

--- a/src/app_engine/analytics_test.py
+++ b/src/app_engine/analytics_test.py
@@ -8,7 +8,6 @@ import apprtc
 import datetime
 import json
 import time
-from constants import LogField
 from google.appengine.api import memcache
 from google.appengine.ext import testbed
 
@@ -91,8 +90,8 @@ class AnalyticsTest(unittest.TestCase):
   def testOnlyEvent(self):
     event_type = 'an_event'
     logDict = self.create_log_dict(
-        {LogField.TIMESTAMP: '{0}'.format(self.now_isoformat()),
-         LogField.EVENT_TYPE: event_type})
+        {analytics.LogField.TIMESTAMP: '{0}'.format(self.now_isoformat()),
+         analytics.LogField.EVENT_TYPE: event_type})
 
     self.tics.report_event(event_type)
     self.assertEqual(logDict, self.bigquery.insertAll.lastKwargs)
@@ -101,9 +100,9 @@ class AnalyticsTest(unittest.TestCase):
     event_type = 'an_event_with_room'
     room_id = 'my_room_that_is_the_best'
     logDict = self.create_log_dict(
-        {LogField.TIMESTAMP: '{0}'.format(self.now_isoformat()),
-         LogField.EVENT_TYPE: event_type,
-         LogField.ROOM_ID: room_id})
+        {analytics.LogField.TIMESTAMP: '{0}'.format(self.now_isoformat()),
+         analytics.LogField.EVENT_TYPE: event_type,
+         analytics.LogField.ROOM_ID: room_id})
 
     self.tics.report_event(event_type, room_id=room_id)
     self.assertEqual(logDict, self.bigquery.insertAll.lastKwargs)
@@ -116,13 +115,13 @@ class AnalyticsTest(unittest.TestCase):
     host = 'super_host.domain.org:8112'
 
     logDict = self.create_log_dict(
-        {LogField.TIMESTAMP: '{0}'.format(
+        {analytics.LogField.TIMESTAMP: '{0}'.format(
              datetime.datetime.fromtimestamp(time_s).isoformat()),
-         LogField.EVENT_TYPE: event_type,
-         LogField.ROOM_ID: room_id,
-         LogField.CLIENT_TIMESTAMP: '{0}'.format(
+         analytics.LogField.EVENT_TYPE: event_type,
+         analytics.LogField.ROOM_ID: room_id,
+         analytics.LogField.CLIENT_TIMESTAMP: '{0}'.format(
              datetime.datetime.fromtimestamp(client_time_s).isoformat()),
-         LogField.HOST: host})
+         analytics.LogField.HOST: host})
 
     self.tics.report_event(event_type,
                            room_id=room_id,

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -361,7 +361,7 @@ def add_client_to_room(request, room_id, client_id, is_loopback):
           %(client_id, room_id, retries))
 
       if room.get_occupancy() == 2:
-        analytics.report_event(constants.EventType.ROOM_SIZE_2,
+        analytics.report_event(analytics.EventType.ROOM_SIZE_2,
                                room_id,
                                host=request.host)
       success = True

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -36,19 +36,3 @@ BIGQUERY_DATASET_LOCAL = 'dev'
 
 # BigQuery table within the dataset.
 BIGQUERY_TABLE = 'analytics'
-
-
-class EventType(object):
-  # Event signifying that a room enters the state of having exactly
-  # two participants.
-  ROOM_SIZE_2 = 'room_size_2'
-
-
-class LogField(object):
-  pass
-
-with open(os.path.join(os.path.dirname(__file__),
-                       'bigquery', 'analytics_schema.json')) as f:
-  schema = json.load(f)
-  for field in schema:
-    setattr(LogField, field['name'].upper(), field['name'])


### PR DESCRIPTION
@tkchin I thought about moving these to constants but the issue is that later I am going to need to generate JS based on some of these enums and I prefer they be namespaced somehow. I think that just making a class to encapsulate them is as good of approach as any.