### PR TITLE
Set up Chrome App shutdown flow.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,14 +145,17 @@ module.exports = function(grunt) {
             'src/web_app/js/adapter.js',
             'src/web_app/js/appcontroller.js',
             'src/web_app/js/call.js',
+            'src/web_app/js/constants.js',
             'src/web_app/js/infobox.js',
             'src/web_app/js/peerconnectionclient.js',
             'src/web_app/js/roomselection.js',
+            'src/web_app/js/remotewebsocket.js',
             'src/web_app/js/sdputils.js',
             'src/web_app/js/signalingchannel.js',
             'src/web_app/js/stats.js',
             'src/web_app/js/storage.js',
             'src/web_app/js/util.js',
+            'src/web_app/js/windowport.js',
           ]
         },
         options: {
@@ -184,7 +187,7 @@ module.exports = function(grunt) {
                                         'shell:getPythonTestDeps',
                                         'shell:runPythonTests',
                                         'shell:removePythonTestsFromOutAppEngineDir']);
-  grunt.registerTask('jstests', ['closurecompiler:debug', 'jstdPhantom']);
+  grunt.registerTask('jstests', ['closurecompiler:debug', 'grunt-chrome-build', 'jstdPhantom']);
   // buildAppEnginePackage must be done before closurecompiler since buildAppEnginePackage resets out/app_engine.
   grunt.registerTask('build', ['shell:buildAppEnginePackage', 'closurecompiler:debug', 'grunt-chrome-build']);
 };

--- a/build/js_test_driver.conf
+++ b/build/js_test_driver.conf
@@ -2,7 +2,9 @@ server: http://localhost:9876
 
 load:
   - ../src/web_app/js/testpolyfills.js
+  - ../src/web_app/js/test_mocks.js
   - ../out/app_engine/js/apprtc.debug.js
+  - ../out/chrome_app/js/background.js
 
 test:
   - ../src/web_app/js/*_test.js

--- a/src/web_app/chrome_app/manifest.json
+++ b/src/web_app/chrome_app/manifest.json
@@ -5,7 +5,7 @@
   "manifest_version": 2,
   "app": {
     "background": {
-      "scripts": ["js/background.js"]
+      "scripts": ["js/apprtc.debug.js", "js/background.js"]
     }
   },
   "icons": {

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -193,7 +193,6 @@ AppController.prototype.showRoomSelection_ = function() {
 AppController.prototype.finishCallSetup_ = function(roomId) {
   this.call_.start(roomId);
 
-  window.onbeforeunload = this.call_.hangup.bind(this.call_);
   document.onkeypress = this.onKeyPress_.bind(this);
   window.onmousemove = this.showIcons_.bind(this);
 
@@ -205,6 +204,13 @@ AppController.prototype.finishCallSetup_ = function(roomId) {
   setUpFullScreen();
 
   if (!isChromeApp()) {
+    // Call hangup with async = false. Required to complete multiple
+    // clean up steps before page is closed.
+    // Chrome apps can't use onbeforeunload.
+    window.onbeforeunload = function() {
+      this.call_.hangup(false);
+    }.bind(this);
+
     window.onpopstate = function(event) {
       if (!event.state) {
         // TODO (chuckhays) : Resetting back to room selection page not
@@ -227,7 +233,8 @@ AppController.prototype.hangup_ = function() {
   this.displayStatus_('Hanging up');
   this.transitionToDone_();
 
-  this.call_.hangup();
+  // Call hangup with async = true.
+  this.call_.hangup(true);
 };
 
 AppController.prototype.onRemoteHangup_ = function() {

--- a/src/web_app/js/background.js
+++ b/src/web_app/js/background.js
@@ -46,20 +46,15 @@
       var ws = new WebSocket(message.wssUrl);
       port.wssPostUrl_ = message.wssPostUrl;
       ws.onopen = function() {
-        trace('RWS: onopen');
         sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONOPEN);
       };
       ws.onerror = function() {
-        trace('RWS: onerror.');
         sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONERROR);
       };
       ws.onclose = function(event) {
-        trace('RWS: onclose - code: ' + event.code + ' reason: ' +
-            event.reason);
         sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONCLOSE, event);
       };
       ws.onmessage = function(event) {
-        trace('RWS: onmessage: ' + event.data);
         sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONMESSAGE, event);
       };
       port.webSocket_ = ws;
@@ -69,7 +64,6 @@
         try {
           port.webSocket_.send(message.data);
         } catch (ex) {
-          trace('RWS: exception sending: ' + ex);
           sendWSEventMessageToWindow(port, Constants.WS_EVENT_SENDERROR, ex);
         }
       } else {

--- a/src/web_app/js/background.js
+++ b/src/web_app/js/background.js
@@ -9,14 +9,152 @@
 /* More information about these options at jshint.com/docs/options */
 
 // Variables defined in and used from chrome.
-/* globals chrome */
+/* globals chrome, sendAsyncUrlRequest, Constants, parseJSON */
 
 'use strict';
-chrome.app.runtime.onLaunched.addListener(function() {
-  chrome.app.window.create('appwindow.html', {
-    'width': 800,
-    'height': 600,
-    'left': 0,
-    'top': 0
+(function() {
+  chrome.app.runtime.onLaunched.addListener(function() {
+    chrome.app.window.create('appwindow.html', {
+      'width': 800,
+      'height': 600,
+      'left': 0,
+      'top': 0
+    });
   });
-});
+
+  // Send event notification from background to window.
+  var sendWSEventMessageToWindow = function(port, wsEvent, data) {
+    var message = {
+        action: Constants.WS_ACTION,
+        wsAction: Constants.EVENT_ACTION,
+        wsEvent: wsEvent
+    };
+    if (data) {
+      message.data = data;
+    }
+    trace('B -> W: ' + JSON.stringify(message));
+    try {
+      port.postMessage(message);
+    } catch (ex) {
+      trace('Error sending message: ' + ex);
+    }
+  };
+
+  var handleWebSocketRequest = function(port, message) {
+    if (message.wsAction === Constants.WS_CREATE_ACTION) {
+      trace('RWS: creating web socket: ' + message.wssUrl);
+      var ws = new WebSocket(message.wssUrl);
+      port.wssPostUrl_ = message.wssPostUrl;
+      ws.onopen = function() {
+        trace('RWS: onopen');
+        sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONOPEN);
+      };
+      ws.onerror = function() {
+        trace('RWS: onerror.');
+        sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONERROR);
+      };
+      ws.onclose = function(event) {
+        trace('RWS: onclose - code: ' + event.code + ' reason: ' +
+            event.reason);
+        sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONCLOSE, event);
+      };
+      ws.onmessage = function(event) {
+        trace('RWS: onmessage: ' + event.data);
+        sendWSEventMessageToWindow(port, Constants.WS_EVENT_ONMESSAGE, event);
+      };
+      port.webSocket_ = ws;
+    } else if (message.wsAction === Constants.WS_SEND_ACTION) {
+      trace('RWS: sending: ' + message.data);
+      if (port.webSocket_ && port.webSocket_.readyState === WebSocket.OPEN) {
+        try {
+          port.webSocket_.send(message.data);
+        } catch (ex) {
+          trace('RWS: exception sending: ' + ex);
+          sendWSEventMessageToWindow(port, Constants.WS_EVENT_SENDERROR, ex);
+        }
+      } else {
+        // Attempt to send message using wss port url.
+        trace('RWS: web socket not ready, falling back to POST.');
+        var msg = parseJSON(message.data);
+        if (msg) {
+          sendAsyncUrlRequest('POST', port.wssPostUrl_, msg.msg);
+        }
+      }
+    } else if (message.wsAction === Constants.WS_CLOSE_ACTION) {
+      trace('RWS: close');
+      if (port.webSocket_) {
+        port.webSocket_.close();
+        port.webSocket = null;
+      }
+    }
+  };
+
+  var executeCleanupTask = function(port, message) {
+    trace('Executing queue action: ' + JSON.stringify(message));
+    if (message.action === Constants.XHR_ACTION) {
+      var method = message.method;
+      var url = message.url;
+      var body = message.body;
+      return sendAsyncUrlRequest(method, url, body);
+    } else if (message.action === Constants.WS_ACTION) {
+      handleWebSocketRequest(port, message);
+    } else {
+      trace('Unknown action in cleanup queue: ' + message.action);
+    }
+  };
+
+  var executeCleanupTasks = function(port, queue) {
+    var promise = Promise.resolve();
+    if (!queue) {
+      return promise;
+    }
+
+    var catchFunction = function(error) {
+      trace('Error executing cleanup action: ' + error.message);
+    };
+
+    while (queue.length > 0) {
+      var queueMessage = queue.shift();
+      promise = promise.then(
+          executeCleanupTask.bind(null, port, queueMessage)
+      ).catch(catchFunction);
+    }
+    return promise;
+  };
+
+  var handleMessageFromWindow = function(port, message) {
+    var action = message.action;
+    if (action === Constants.WS_ACTION) {
+      handleWebSocketRequest(port, message);
+    } else if (action === Constants.QUEUECLEAR_ACTION) {
+      port.queue_ = [];
+    } else if (action === Constants.QUEUEADD_ACTION) {
+      if (!port.queue_) {
+        port.queue_ = [];
+      }
+      port.queue_.push(message.queueMessage);
+    } else {
+      trace('Unknown action from window: ' + action);
+    }
+  };
+
+  chrome.runtime.onConnect.addListener(function(port) {
+    port.onDisconnect.addListener(function() {
+      // Execute the cleanup queue.
+      executeCleanupTasks(port, port.queue_).then(function() {
+        // Close web socket.
+        if (port.webSocket_) {
+          trace('Closing web socket.');
+          port.webSocket_.close();
+          port.webSocket_ = null;
+        }
+      });
+    });
+
+    port.onMessage.addListener(function(message) {
+      // Handle message from window to background.
+      trace('W -> B: ' + JSON.stringify(message));
+      handleMessageFromWindow(port, message);
+    });
+  });
+})();

--- a/src/web_app/js/background_test.js
+++ b/src/web_app/js/background_test.js
@@ -1,0 +1,248 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+
+/* globals TestCase, assertEquals, xhrs:true, MockWebSocket, FAKE_WSS_POST_URL,
+   Constants, webSockets:true, FAKE_WSS_URL, WebSocket:true, MockXMLHttpRequest,
+   XMLHttpRequest:true, FAKE_SEND_EXCEPTION */
+
+'use strict';
+var FAKE_MESSAGE = JSON.stringify({
+        cmd: 'send',
+        msg: JSON.stringify({type: 'bye'})
+      });
+
+var MockEvent = function(addListener) {
+  this.addListener_ = addListener;
+};
+
+MockEvent.prototype.addListener = function(callback) {
+  this.addListener_(callback);
+};
+
+var MockPort = function() {
+  this.onDisconnectCallback_ = null;
+  this.onMessageCallback_ = null;
+  this.onPostMessage = null;
+
+  this.onDisconnect = new MockEvent(function(callback) {
+    this.onDisconnectCallback_ = callback;
+  }.bind(this));
+
+  this.onMessage = new MockEvent(function(callback) {
+    this.onMessageCallback_ = callback;
+  }.bind(this));
+};
+
+MockPort.prototype.disconnect = function() {
+  if (this.onDisconnectCallback_) {
+    this.onDisconnectCallback_();
+  }
+};
+
+MockPort.prototype.message = function(message) {
+  if (this.onMessageCallback_) {
+    this.onMessageCallback_(message);
+  }
+};
+
+MockPort.prototype.postMessage = function(message) {
+  if (this.onPostMessage) {
+    this.onPostMessage(message);
+  }
+};
+
+MockPort.prototype.createWebSocket = function() {
+  assertEquals(0, webSockets.length);
+
+  this.message({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_CREATE_ACTION,
+    wssUrl: FAKE_WSS_URL,
+    wssPostUrl: FAKE_WSS_POST_URL
+  });
+
+  assertEquals(1, webSockets.length);
+
+  assertEquals(WebSocket.CONNECTING, this.webSocket_.readyState);
+};
+
+var BackgroundTest = new TestCase('BackgroundTest');
+
+BackgroundTest.prototype.setUp = function() {
+  webSockets = [];
+  xhrs = [];
+
+  this.realWebSocket = WebSocket;
+  WebSocket = MockWebSocket;
+
+  this.mockPort_ = new MockPort();
+  window.chrome.callOnConnect(this.mockPort_);
+};
+
+BackgroundTest.prototype.tearDown = function() {
+  WebSocket = this.realWebSocket;
+};
+
+BackgroundTest.prototype.testCreateWebSocket = function() {
+  this.mockPort_.createWebSocket();
+};
+
+BackgroundTest.prototype.testCloseWebSocket = function() {
+  this.mockPort_.createWebSocket();
+
+  this.mockPort_.message({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_CLOSE_ACTION
+  });
+
+  assertEquals(WebSocket.CLOSED, this.mockPort_.webSocket_.readyState);
+};
+
+BackgroundTest.prototype.testSendWebSocket = function() {
+  this.mockPort_.createWebSocket();
+
+  this.mockPort_.webSocket_.simulateOpenResult(true);
+
+  assertEquals(0, this.mockPort_.webSocket_.messages.length);
+  this.mockPort_.message({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_SEND_ACTION,
+    data: FAKE_MESSAGE
+  });
+  assertEquals(1, this.mockPort_.webSocket_.messages.length);
+  assertEquals(FAKE_MESSAGE, this.mockPort_.webSocket_.messages[0]);
+};
+
+BackgroundTest.prototype.testSendWebSocketNotReady = function() {
+  this.mockPort_.createWebSocket();
+
+  // Send without socket being in open state.
+  assertEquals(0, this.mockPort_.webSocket_.messages.length);
+  var realXMLHttpRequest = XMLHttpRequest;
+  XMLHttpRequest = MockXMLHttpRequest;
+  this.mockPort_.message({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_SEND_ACTION,
+    data: FAKE_MESSAGE
+  });
+  XMLHttpRequest = realXMLHttpRequest;
+  // No messages posted to web socket.
+  assertEquals(0, this.mockPort_.webSocket_.messages.length);
+
+  // Message sent via xhr instead.
+  assertEquals(1, xhrs.length);
+  assertEquals(2, xhrs[0].readyState);
+  assertEquals(FAKE_WSS_POST_URL, xhrs[0].url);
+  assertEquals('POST', xhrs[0].method);
+  assertEquals(JSON.stringify({type: 'bye'}), xhrs[0].body);
+};
+
+BackgroundTest.prototype.testSendWebSocketThrows = function() {
+  this.mockPort_.createWebSocket();
+
+  this.mockPort_.webSocket_.simulateOpenResult(true);
+
+  // Set mock web socket to throw exception on send().
+  this.mockPort_.webSocket_.throwOnSend = true;
+
+  var message = null;
+  this.mockPort_.onPostMessage = function(msg) {
+    message = msg;
+  };
+
+  assertEquals(0, this.mockPort_.webSocket_.messages.length);
+  this.mockPort_.message({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_SEND_ACTION,
+    data: FAKE_MESSAGE
+  });
+  assertEquals(0, this.mockPort_.webSocket_.messages.length);
+
+  this.checkMessage_(message,
+                     Constants.WS_EVENT_SENDERROR, FAKE_SEND_EXCEPTION);
+};
+
+BackgroundTest.prototype.checkMessage_ = function(m, wsEvent, data) {
+  assertEquals(Constants.WS_ACTION, m.action);
+  assertEquals(Constants.EVENT_ACTION, m.wsAction);
+  assertEquals(wsEvent, m.wsEvent);
+  if (data) {
+    assertEquals(data, m.data);
+  }
+};
+
+BackgroundTest.prototype.testWebSocketEvents = function() {
+  this.mockPort_.createWebSocket();
+  var message = null;
+  this.mockPort_.onPostMessage = function(msg) {
+    message = msg;
+  };
+
+  var ws = this.mockPort_.webSocket_;
+
+  ws.onopen();
+  this.checkMessage_(message, Constants.WS_EVENT_ONOPEN);
+
+  ws.onerror();
+  this.checkMessage_(message, Constants.WS_EVENT_ONERROR);
+
+  ws.onclose(FAKE_MESSAGE);
+  this.checkMessage_(message, Constants.WS_EVENT_ONCLOSE, FAKE_MESSAGE);
+
+  ws.onmessage(FAKE_MESSAGE);
+  this.checkMessage_(message, Constants.WS_EVENT_ONMESSAGE, FAKE_MESSAGE);
+};
+
+BackgroundTest.prototype.testDisconnectClosesWebSocket = function() {
+  // Disconnect should cause web socket to be closed.
+  var socketClosed = false;
+
+  this.mockPort_.webSocket_ = {
+    close: function() {
+      socketClosed = true;
+    }
+  };
+  this.mockPort_.disconnect();
+
+  assertEquals(true, socketClosed);
+};
+
+BackgroundTest.prototype.testQueueMessages = function() {
+  assertEquals(null, this.mockPort_.queue_);
+
+  this.mockPort_.message({
+    action: Constants.QUEUEADD_ACTION,
+    queueMessage: {
+      action: Constants.XHR_ACTION,
+      method: 'POST',
+      url: '/go/home',
+      body: null
+    }
+  });
+
+  assertEquals(1, this.mockPort_.queue_.length);
+
+  this.mockPort_.message({
+    action: Constants.QUEUEADD_ACTION,
+    queueMessage: {
+      action: Constants.WS_ACTION,
+      wsAction: Constants.WS_SEND_ACTION,
+      data: JSON.stringify({
+        cmd: 'send',
+        msg: JSON.stringify({type: 'bye'})
+      })
+    }
+  });
+
+  assertEquals(2, this.mockPort_.queue_.length);
+
+  this.mockPort_.message({action: Constants.QUEUECLEAR_ACTION});
+  assertEquals([], this.mockPort_.queue_);
+};

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -10,7 +10,7 @@
 
 /* globals trace, requestTurnServers, sendUrlRequest, sendAsyncUrlRequest,
    requestUserMedia, SignalingChannel, PeerConnectionClient, setupLoopback,
-   parseJSON, isChromeApp, WindowPort, Constants */
+   parseJSON, isChromeApp, apprtc, Constants */
 
 /* exported Call */
 
@@ -65,7 +65,7 @@ Call.prototype.queueCleanupMessages_ = function() {
   // Set up the cleanup queue.
   // These steps mirror the cleanup done in hangup(), but will be
   // executed when the Chrome App is closed by background.js.
-  WindowPort.sendMessage({
+  apprtc.windowPort.sendMessage({
     action: Constants.QUEUEADD_ACTION,
     queueMessage: {
       action: Constants.XHR_ACTION,
@@ -75,7 +75,7 @@ Call.prototype.queueCleanupMessages_ = function() {
     }
   });
 
-  WindowPort.sendMessage({
+  apprtc.windowPort.sendMessage({
     action: Constants.QUEUEADD_ACTION,
     queueMessage: {
       action: Constants.WS_ACTION,
@@ -87,7 +87,7 @@ Call.prototype.queueCleanupMessages_ = function() {
     }
   });
 
-  WindowPort.sendMessage({
+  apprtc.windowPort.sendMessage({
     action: Constants.QUEUEADD_ACTION,
     queueMessage: {
       action: Constants.XHR_ACTION,
@@ -100,7 +100,7 @@ Call.prototype.queueCleanupMessages_ = function() {
 
 Call.prototype.clearCleanupQueue_ = function() {
   // Clear the cleanup queue.
-  WindowPort.sendMessage({action: Constants.QUEUECLEAR_ACTION});
+  apprtc.windowPort.sendMessage({action: Constants.QUEUECLEAR_ACTION});
 };
 
 Call.prototype.restart = function() {

--- a/src/web_app/js/call_test.js
+++ b/src/web_app/js/call_test.js
@@ -9,7 +9,8 @@
 /* More information about these options at jshint.com/docs/options */
 
 /* globals TestCase, SignalingChannel:true, requestUserMedia:true,
-   assertEquals, assertTrue */
+   assertEquals, assertTrue, MockWindowPort, FAKE_WSS_POST_URL, FAKE_ROOM_ID,
+   FAKE_CLIENT_ID, WindowPort:true, Constants */
 
 'use strict';
 
@@ -20,6 +21,10 @@ var MockSignalingChannel = function() {
 
 MockSignalingChannel.prototype.open = function() {
   return Promise.resolve();
+};
+
+MockSignalingChannel.prototype.getWssPostUrl = function() {
+  return FAKE_WSS_POST_URL;
 };
 
 var CallTest = new TestCase('CallTest');
@@ -39,7 +44,9 @@ CallTest.prototype.setUp = function() {
   this.params_ = {
     mediaConstraints: {
       audio: true, video: true
-    }
+    },
+    roomId: FAKE_ROOM_ID,
+    clientId: FAKE_CLIENT_ID
   };
 };
 
@@ -57,4 +64,53 @@ CallTest.prototype.testRestartInitializesMedia = function() {
   };
   call.restart();
   assertTrue(mediaStarted);
+};
+
+CallTest.prototype.testSetUpCleanupQueue = function() {
+  var realWindowPort = WindowPort;
+  WindowPort = new MockWindowPort();
+
+  var call = new Call(this.params_);
+  assertEquals(0, WindowPort.messages.length);
+  call.queueCleanupMessages_();
+  assertEquals(3, WindowPort.messages.length);
+
+  var verifyXhrMessage = function(message, method, url) {
+    assertEquals(Constants.QUEUEADD_ACTION, message.action);
+    assertEquals(Constants.XHR_ACTION, message.queueMessage.action);
+    assertEquals(method, message.queueMessage.method);
+    assertEquals(url, message.queueMessage.url);
+    assertEquals(null, message.queueMessage.body);
+  };
+
+  verifyXhrMessage(WindowPort.messages[0], 'POST', '/leave/' + FAKE_ROOM_ID +
+      '/' + FAKE_CLIENT_ID);
+  verifyXhrMessage(WindowPort.messages[2], 'DELETE', FAKE_WSS_POST_URL);
+
+  var message = WindowPort.messages[1];
+  assertEquals(Constants.QUEUEADD_ACTION, message.action);
+  assertEquals(Constants.WS_ACTION, message.queueMessage.action);
+  assertEquals(Constants.WS_SEND_ACTION, message.queueMessage.wsAction);
+  var data = JSON.parse(message.queueMessage.data);
+  assertEquals('send', data.cmd);
+  var msg = JSON.parse(data.msg);
+  assertEquals('bye', msg.type);
+
+  WindowPort = realWindowPort;
+};
+
+CallTest.prototype.testClearCleanupQueue = function() {
+  var realWindowPort = WindowPort;
+  WindowPort = new MockWindowPort();
+
+  var call = new Call(this.params_);
+  call.queueCleanupMessages_();
+  assertEquals(3, WindowPort.messages.length);
+
+  call.clearCleanupQueue_();
+  assertEquals(4, WindowPort.messages.length);
+  var message = WindowPort.messages[3];
+  assertEquals(Constants.QUEUECLEAR_ACTION, message.action);
+
+  WindowPort = realWindowPort;
 };

--- a/src/web_app/js/call_test.js
+++ b/src/web_app/js/call_test.js
@@ -10,21 +10,34 @@
 
 /* globals TestCase, SignalingChannel:true, requestUserMedia:true,
    assertEquals, assertTrue, MockWindowPort, FAKE_WSS_POST_URL, FAKE_ROOM_ID,
-   FAKE_CLIENT_ID, apprtc, Constants */
+   FAKE_CLIENT_ID, apprtc, Constants, xhrs, MockXMLHttpRequest, assertFalse,
+   XMLHttpRequest:true */
 
 'use strict';
 
+var FAKE_LEAVE_URL = '/leave/' + FAKE_ROOM_ID + '/' + FAKE_CLIENT_ID;
 var MEDIA_STREAM_OBJECT = {value: 'stream'};
 
 var MockSignalingChannel = function() {
 };
 
+MockSignalingChannel.isOpen = null;
 MockSignalingChannel.prototype.open = function() {
+  MockSignalingChannel.isOpen = true;
   return Promise.resolve();
 };
 
 MockSignalingChannel.prototype.getWssPostUrl = function() {
   return FAKE_WSS_POST_URL;
+};
+
+MockSignalingChannel.sends = [];
+MockSignalingChannel.prototype.send = function(data) {
+  MockSignalingChannel.sends.push(data);
+};
+
+MockSignalingChannel.prototype.close = function() {
+  MockSignalingChannel.isOpen = false;
 };
 
 var CallTest = new TestCase('CallTest');
@@ -83,8 +96,7 @@ CallTest.prototype.testSetUpCleanupQueue = function() {
     assertEquals(null, message.queueMessage.body);
   };
 
-  verifyXhrMessage(apprtc.windowPort.messages[0], 'POST', '/leave/' +
-      FAKE_ROOM_ID + '/' + FAKE_CLIENT_ID);
+  verifyXhrMessage(apprtc.windowPort.messages[0], 'POST', FAKE_LEAVE_URL);
   verifyXhrMessage(apprtc.windowPort.messages[2], 'DELETE',
       FAKE_WSS_POST_URL);
 
@@ -114,4 +126,40 @@ CallTest.prototype.testClearCleanupQueue = function() {
   assertEquals(Constants.QUEUECLEAR_ACTION, message.action);
 
   apprtc.windowPort = realWindowPort;
+};
+
+CallTest.prototype.testCallHangupSync = function() {
+  var call = new Call(this.params_);
+  var stopCalled = false;
+  var closeCalled = false;
+  call.localStream_ = {stop: function() {stopCalled = true; }};
+  call.pcClient_ = {close: function() {closeCalled = true; }};
+
+  assertEquals(0, xhrs.length);
+  assertEquals(0, MockSignalingChannel.sends.length);
+  assertTrue(MockSignalingChannel.isOpen !== false);
+  var realXMLHttpRequest = XMLHttpRequest;
+  XMLHttpRequest = MockXMLHttpRequest;
+
+  call.hangup(false);
+  XMLHttpRequest = realXMLHttpRequest;
+
+  assertEquals(true, stopCalled);
+  assertEquals(true, closeCalled);
+  // Send /leave.
+  assertEquals(1, xhrs.length);
+  assertEquals(FAKE_LEAVE_URL, xhrs[0].url);
+  assertEquals('POST', xhrs[0].method);
+
+  // Send 'bye' to ws.
+  assertEquals(1, MockSignalingChannel.sends.length);
+  assertEquals(JSON.stringify({type: 'bye'}), MockSignalingChannel.sends[0]);
+
+  // Close ws.
+  assertFalse(MockSignalingChannel.isOpen);
+
+  // Clean up params state.
+  assertEquals(null, call.params_.roomId);
+  assertEquals(null, call.params_.clientId);
+  assertEquals(FAKE_ROOM_ID, call.params_.previousRoomId);
 };

--- a/src/web_app/js/call_test.js
+++ b/src/web_app/js/call_test.js
@@ -10,7 +10,7 @@
 
 /* globals TestCase, SignalingChannel:true, requestUserMedia:true,
    assertEquals, assertTrue, MockWindowPort, FAKE_WSS_POST_URL, FAKE_ROOM_ID,
-   FAKE_CLIENT_ID, WindowPort:true, Constants */
+   FAKE_CLIENT_ID, apprtc, Constants */
 
 'use strict';
 
@@ -67,13 +67,13 @@ CallTest.prototype.testRestartInitializesMedia = function() {
 };
 
 CallTest.prototype.testSetUpCleanupQueue = function() {
-  var realWindowPort = WindowPort;
-  WindowPort = new MockWindowPort();
+  var realWindowPort = apprtc.windowPort;
+  apprtc.windowPort = new MockWindowPort();
 
   var call = new Call(this.params_);
-  assertEquals(0, WindowPort.messages.length);
+  assertEquals(0, apprtc.windowPort.messages.length);
   call.queueCleanupMessages_();
-  assertEquals(3, WindowPort.messages.length);
+  assertEquals(3, apprtc.windowPort.messages.length);
 
   var verifyXhrMessage = function(message, method, url) {
     assertEquals(Constants.QUEUEADD_ACTION, message.action);
@@ -83,11 +83,12 @@ CallTest.prototype.testSetUpCleanupQueue = function() {
     assertEquals(null, message.queueMessage.body);
   };
 
-  verifyXhrMessage(WindowPort.messages[0], 'POST', '/leave/' + FAKE_ROOM_ID +
-      '/' + FAKE_CLIENT_ID);
-  verifyXhrMessage(WindowPort.messages[2], 'DELETE', FAKE_WSS_POST_URL);
+  verifyXhrMessage(apprtc.windowPort.messages[0], 'POST', '/leave/' +
+      FAKE_ROOM_ID + '/' + FAKE_CLIENT_ID);
+  verifyXhrMessage(apprtc.windowPort.messages[2], 'DELETE',
+      FAKE_WSS_POST_URL);
 
-  var message = WindowPort.messages[1];
+  var message = apprtc.windowPort.messages[1];
   assertEquals(Constants.QUEUEADD_ACTION, message.action);
   assertEquals(Constants.WS_ACTION, message.queueMessage.action);
   assertEquals(Constants.WS_SEND_ACTION, message.queueMessage.wsAction);
@@ -96,21 +97,21 @@ CallTest.prototype.testSetUpCleanupQueue = function() {
   var msg = JSON.parse(data.msg);
   assertEquals('bye', msg.type);
 
-  WindowPort = realWindowPort;
+  apprtc.windowPort = realWindowPort;
 };
 
 CallTest.prototype.testClearCleanupQueue = function() {
-  var realWindowPort = WindowPort;
-  WindowPort = new MockWindowPort();
+  var realWindowPort = apprtc.windowPort;
+  apprtc.windowPort = new MockWindowPort();
 
   var call = new Call(this.params_);
   call.queueCleanupMessages_();
-  assertEquals(3, WindowPort.messages.length);
+  assertEquals(3, apprtc.windowPort.messages.length);
 
   call.clearCleanupQueue_();
-  assertEquals(4, WindowPort.messages.length);
-  var message = WindowPort.messages[3];
+  assertEquals(4, apprtc.windowPort.messages.length);
+  var message = apprtc.windowPort.messages[3];
   assertEquals(Constants.QUEUECLEAR_ACTION, message.action);
 
-  WindowPort = realWindowPort;
+  apprtc.windowPort = realWindowPort;
 };

--- a/src/web_app/js/constants.js
+++ b/src/web_app/js/constants.js
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+
+/* exported Constants */
+'use strict';
+
+var Constants = {
+  // Action type for remote web socket communication.
+  WS_ACTION: 'ws',
+  // Action type for remote xhr communication.
+  XHR_ACTION: 'xhr',
+  // Action type for adding a command to the remote clean up queue.
+  QUEUEADD_ACTION: 'addToQueue',
+  // Action type for clearing the remote clean up queue.
+  QUEUECLEAR_ACTION: 'clearQueue',
+  // Web socket action type specifying that an event occured.
+  EVENT_ACTION: 'event',
+
+  // Web socket action type to create a remote web socket.
+  WS_CREATE_ACTION: 'create',
+  // Web socket event type onerror.
+  WS_EVENT_ONERROR: 'onerror',
+  // Web socket event type onmessage.
+  WS_EVENT_ONMESSAGE: 'onmessage',
+  // Web socket event type onopen.
+  WS_EVENT_ONOPEN: 'onopen',
+  // Web socket event type onclose.
+  WS_EVENT_ONCLOSE: 'onclose',
+  // Web socket event sent when an error occurs while calling send.
+  WS_EVENT_SENDERROR: 'onsenderror',
+  // Web socket action type to send a message on the remote web socket.
+  WS_SEND_ACTION: 'send',
+  // Web socket action type to close the remote web socket.
+  WS_CLOSE_ACTION: 'close'
+};

--- a/src/web_app/js/remotewebsocket.js
+++ b/src/web_app/js/remotewebsocket.js
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+
+/* globals WindowPort, Constants */
+/* exported RemoteWebSocket */
+
+'use strict';
+
+// This class is used as a proxy for the WebSocket owned by background.js.
+// This proxy class sends commands and receives events via a Port object
+// opened to communicate with background.js in a Chrome App.
+// The WebSocket object must be owned by background.js so the call can be
+// properly terminated when the app window is closed.
+var RemoteWebSocket = function(wssUrl, wssPostUrl) {
+  this.wssUrl_ = wssUrl;
+  WindowPort.addMessageListener(this.handleMessage_.bind(this));
+  this.sendMessage_({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_CREATE_ACTION,
+    wssUrl: wssUrl,
+    wssPostUrl: wssPostUrl
+  });
+  this.readyState = WebSocket.CONNECTING;
+};
+
+RemoteWebSocket.prototype.sendMessage_ = function(message) {
+  WindowPort.sendMessage(message);
+};
+
+RemoteWebSocket.prototype.send = function(data) {
+  if (this.readyState !== WebSocket.OPEN) {
+    throw 'Web socket is not in OPEN state: ' + this.readyState;
+  }
+  this.sendMessage_({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_SEND_ACTION,
+    data: data
+  });
+};
+
+RemoteWebSocket.prototype.close = function() {
+  if (this.readyState === WebSocket.CLOSING ||
+      this.readyState === WebSocket.CLOSED) {
+    return;
+  }
+  this.readyState = WebSocket.CLOSING;
+  this.sendMessage_({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.WS_CLOSE_ACTION
+  });
+};
+
+RemoteWebSocket.prototype.handleMessage_ = function(message) {
+  if (message.action === Constants.WS_ACTION &&
+        message.wsAction === Constants.EVENT_ACTION) {
+    if (message.wsEvent === Constants.WS_EVENT_ONOPEN) {
+      this.readyState = WebSocket.OPEN;
+      if (this.onopen) {
+        this.onopen();
+      }
+    } else if (message.wsEvent === Constants.WS_EVENT_ONCLOSE) {
+      this.readyState = WebSocket.CLOSED;
+      if (this.onclose) {
+        this.onclose(message.data);
+      }
+    } else if (message.wsEvent === Constants.WS_EVENT_ONERROR) {
+      if (this.onerror) {
+        this.onerror(message.data);
+      }
+    } else if (message.wsEvent === Constants.WS_EVENT_ONMESSAGE) {
+      if (this.onmessage) {
+        this.onmessage(message.data);
+      }
+    } else if (message.wsEvent === Constants.WS_EVENT_SENDERROR) {
+      if (this.onsenderror) {
+        this.onsenderror(message.data);
+      }
+      trace('ERROR: web socket send failed: ' + message.data);
+    }
+  }
+};

--- a/src/web_app/js/remotewebsocket.js
+++ b/src/web_app/js/remotewebsocket.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* globals WindowPort, Constants */
+/* globals apprtc, Constants */
 /* exported RemoteWebSocket */
 
 'use strict';
@@ -20,7 +20,7 @@
 // properly terminated when the app window is closed.
 var RemoteWebSocket = function(wssUrl, wssPostUrl) {
   this.wssUrl_ = wssUrl;
-  WindowPort.addMessageListener(this.handleMessage_.bind(this));
+  apprtc.windowPort.addMessageListener(this.handleMessage_.bind(this));
   this.sendMessage_({
     action: Constants.WS_ACTION,
     wsAction: Constants.WS_CREATE_ACTION,
@@ -31,7 +31,7 @@ var RemoteWebSocket = function(wssUrl, wssPostUrl) {
 };
 
 RemoteWebSocket.prototype.sendMessage_ = function(message) {
-  WindowPort.sendMessage(message);
+  apprtc.windowPort.sendMessage(message);
 };
 
 RemoteWebSocket.prototype.send = function(data) {

--- a/src/web_app/js/remotewebsocket_test.js
+++ b/src/web_app/js/remotewebsocket_test.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* globals TestCase, assertEquals, Constants, FAKE_WSS_URL, WindowPort:true,
+/* globals TestCase, assertEquals, Constants, FAKE_WSS_URL, apprtc,
    RemoteWebSocket, MockWindowPort */
 
 'use strict';
@@ -17,21 +17,22 @@ var TEST_MESSAGE = 'foobar';
 var RemoteWebSocketTest = new TestCase('RemoteWebSocketTest');
 
 RemoteWebSocketTest.prototype.setUp = function() {
-  this.realWindowPort = WindowPort;
-  WindowPort = new MockWindowPort();
+  this.realWindowPort = apprtc.windowPort;
+  apprtc.windowPort = new MockWindowPort();
 
   this.rws_ = new RemoteWebSocket(FAKE_WSS_URL);
   // Should have an message to request create.
-  assertEquals(1, WindowPort.messages.length);
-  assertEquals(Constants.WS_ACTION, WindowPort.messages[0].action);
-  assertEquals(Constants.WS_CREATE_ACTION, WindowPort.messages[0].wsAction);
-  assertEquals(FAKE_WSS_URL, WindowPort.messages[0].wssUrl);
+  assertEquals(1, apprtc.windowPort.messages.length);
+  assertEquals(Constants.WS_ACTION, apprtc.windowPort.messages[0].action);
+  assertEquals(Constants.WS_CREATE_ACTION,
+      apprtc.windowPort.messages[0].wsAction);
+  assertEquals(FAKE_WSS_URL, apprtc.windowPort.messages[0].wssUrl);
   assertEquals(WebSocket.CONNECTING, this.rws_.readyState);
 
 };
 
 RemoteWebSocketTest.prototype.tearDown = function() {
-  WindowPort = this.realWindowPort;
+  apprtc.windowPort = this.realWindowPort;
 };
 
 RemoteWebSocketTest.prototype.testSendBeforeOpen = function() {
@@ -48,19 +49,20 @@ RemoteWebSocketTest.prototype.testSendBeforeOpen = function() {
 };
 
 RemoteWebSocketTest.prototype.testSend = function() {
-  WindowPort.simulateMessageFromBackground({
+  apprtc.windowPort.simulateMessageFromBackground({
     action: Constants.WS_ACTION,
     wsAction: Constants.EVENT_ACTION,
     wsEvent: Constants.WS_EVENT_ONOPEN,
     data: TEST_MESSAGE
   });
 
-  assertEquals(1, WindowPort.messages.length);
+  assertEquals(1, apprtc.windowPort.messages.length);
   this.rws_.send(TEST_MESSAGE);
-  assertEquals(2, WindowPort.messages.length);
-  assertEquals(Constants.WS_ACTION, WindowPort.messages[1].action);
-  assertEquals(Constants.WS_SEND_ACTION, WindowPort.messages[1].wsAction);
-  assertEquals(TEST_MESSAGE, WindowPort.messages[1].data);
+  assertEquals(2, apprtc.windowPort.messages.length);
+  assertEquals(Constants.WS_ACTION, apprtc.windowPort.messages[1].action);
+  assertEquals(Constants.WS_SEND_ACTION,
+      apprtc.windowPort.messages[1].wsAction);
+  assertEquals(TEST_MESSAGE, apprtc.windowPort.messages[1].data);
 };
 
 RemoteWebSocketTest.prototype.testClose = function() {
@@ -71,15 +73,16 @@ RemoteWebSocketTest.prototype.testClose = function() {
     message = e;
   };
 
-  assertEquals(1, WindowPort.messages.length);
+  assertEquals(1, apprtc.windowPort.messages.length);
   this.rws_.close();
 
-  assertEquals(2, WindowPort.messages.length);
-  assertEquals(Constants.WS_ACTION, WindowPort.messages[1].action);
-  assertEquals(Constants.WS_CLOSE_ACTION, WindowPort.messages[1].wsAction);
+  assertEquals(2, apprtc.windowPort.messages.length);
+  assertEquals(Constants.WS_ACTION, apprtc.windowPort.messages[1].action);
+  assertEquals(Constants.WS_CLOSE_ACTION,
+      apprtc.windowPort.messages[1].wsAction);
 
   assertEquals(WebSocket.CLOSING, this.rws_.readyState);
-  WindowPort.simulateMessageFromBackground({
+  apprtc.windowPort.simulateMessageFromBackground({
     action: Constants.WS_ACTION,
     wsAction: Constants.EVENT_ACTION,
     wsEvent: Constants.WS_EVENT_ONCLOSE,
@@ -98,7 +101,7 @@ RemoteWebSocketTest.prototype.testOnError = function() {
     message = e;
   };
 
-  WindowPort.simulateMessageFromBackground({
+  apprtc.windowPort.simulateMessageFromBackground({
     action: Constants.WS_ACTION,
     wsAction: Constants.EVENT_ACTION,
     wsEvent: Constants.WS_EVENT_ONERROR,
@@ -114,7 +117,7 @@ RemoteWebSocketTest.prototype.testOnOpen = function() {
     called = true;
   };
 
-  WindowPort.simulateMessageFromBackground({
+  apprtc.windowPort.simulateMessageFromBackground({
     action: Constants.WS_ACTION,
     wsAction: Constants.EVENT_ACTION,
     wsEvent: Constants.WS_EVENT_ONOPEN,
@@ -132,7 +135,7 @@ RemoteWebSocketTest.prototype.testOnMessage = function() {
     message = e;
   };
 
-  WindowPort.simulateMessageFromBackground({
+  apprtc.windowPort.simulateMessageFromBackground({
     action: Constants.WS_ACTION,
     wsAction: Constants.EVENT_ACTION,
     wsEvent: Constants.WS_EVENT_ONMESSAGE,
@@ -150,7 +153,7 @@ RemoteWebSocketTest.prototype.testOnSendError = function() {
     message = e;
   };
 
-  WindowPort.simulateMessageFromBackground({
+  apprtc.windowPort.simulateMessageFromBackground({
     action: Constants.WS_ACTION,
     wsAction: Constants.EVENT_ACTION,
     wsEvent: Constants.WS_EVENT_SENDERROR,

--- a/src/web_app/js/remotewebsocket_test.js
+++ b/src/web_app/js/remotewebsocket_test.js
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+
+/* globals TestCase, assertEquals, Constants, FAKE_WSS_URL, WindowPort:true,
+   RemoteWebSocket, MockWindowPort */
+
+'use strict';
+var TEST_MESSAGE = 'foobar';
+
+var RemoteWebSocketTest = new TestCase('RemoteWebSocketTest');
+
+RemoteWebSocketTest.prototype.setUp = function() {
+  this.realWindowPort = WindowPort;
+  WindowPort = new MockWindowPort();
+
+  this.rws_ = new RemoteWebSocket(FAKE_WSS_URL);
+  // Should have an message to request create.
+  assertEquals(1, WindowPort.messages.length);
+  assertEquals(Constants.WS_ACTION, WindowPort.messages[0].action);
+  assertEquals(Constants.WS_CREATE_ACTION, WindowPort.messages[0].wsAction);
+  assertEquals(FAKE_WSS_URL, WindowPort.messages[0].wssUrl);
+  assertEquals(WebSocket.CONNECTING, this.rws_.readyState);
+
+};
+
+RemoteWebSocketTest.prototype.tearDown = function() {
+  WindowPort = this.realWindowPort;
+};
+
+RemoteWebSocketTest.prototype.testSendBeforeOpen = function() {
+  var exception = false;
+  try {
+    this.rws_.send(TEST_MESSAGE);
+  } catch (ex) {
+    if (ex) {
+      exception = true;
+    }
+  }
+
+  assertEquals(true, exception);
+};
+
+RemoteWebSocketTest.prototype.testSend = function() {
+  WindowPort.simulateMessageFromBackground({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.EVENT_ACTION,
+    wsEvent: Constants.WS_EVENT_ONOPEN,
+    data: TEST_MESSAGE
+  });
+
+  assertEquals(1, WindowPort.messages.length);
+  this.rws_.send(TEST_MESSAGE);
+  assertEquals(2, WindowPort.messages.length);
+  assertEquals(Constants.WS_ACTION, WindowPort.messages[1].action);
+  assertEquals(Constants.WS_SEND_ACTION, WindowPort.messages[1].wsAction);
+  assertEquals(TEST_MESSAGE, WindowPort.messages[1].data);
+};
+
+RemoteWebSocketTest.prototype.testClose = function() {
+  var message = null;
+  var called = false;
+  this.rws_.onclose = function(e) {
+    called = true;
+    message = e;
+  };
+
+  assertEquals(1, WindowPort.messages.length);
+  this.rws_.close();
+
+  assertEquals(2, WindowPort.messages.length);
+  assertEquals(Constants.WS_ACTION, WindowPort.messages[1].action);
+  assertEquals(Constants.WS_CLOSE_ACTION, WindowPort.messages[1].wsAction);
+
+  assertEquals(WebSocket.CLOSING, this.rws_.readyState);
+  WindowPort.simulateMessageFromBackground({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.EVENT_ACTION,
+    wsEvent: Constants.WS_EVENT_ONCLOSE,
+    data: TEST_MESSAGE
+  });
+  assertEquals(true, called);
+  assertEquals(TEST_MESSAGE, message);
+  assertEquals(WebSocket.CLOSED, this.rws_.readyState);
+};
+
+RemoteWebSocketTest.prototype.testOnError = function() {
+  var message = null;
+  var called = false;
+  this.rws_.onerror = function(e) {
+    called = true;
+    message = e;
+  };
+
+  WindowPort.simulateMessageFromBackground({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.EVENT_ACTION,
+    wsEvent: Constants.WS_EVENT_ONERROR,
+    data: TEST_MESSAGE
+  });
+  assertEquals(true, called);
+  assertEquals(TEST_MESSAGE, message);
+};
+
+RemoteWebSocketTest.prototype.testOnOpen = function() {
+  var called = false;
+  this.rws_.onopen = function() {
+    called = true;
+  };
+
+  WindowPort.simulateMessageFromBackground({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.EVENT_ACTION,
+    wsEvent: Constants.WS_EVENT_ONOPEN,
+    data: TEST_MESSAGE
+  });
+  assertEquals(true, called);
+  assertEquals(WebSocket.OPEN, this.rws_.readyState);
+};
+
+RemoteWebSocketTest.prototype.testOnMessage = function() {
+  var message = null;
+  var called = false;
+  this.rws_.onmessage = function(e) {
+    called = true;
+    message = e;
+  };
+
+  WindowPort.simulateMessageFromBackground({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.EVENT_ACTION,
+    wsEvent: Constants.WS_EVENT_ONMESSAGE,
+    data: TEST_MESSAGE
+  });
+  assertEquals(true, called);
+  assertEquals(TEST_MESSAGE, message);
+};
+
+RemoteWebSocketTest.prototype.testOnSendError = function() {
+  var message = null;
+  var called = false;
+  this.rws_.onsenderror = function(e) {
+    called = true;
+    message = e;
+  };
+
+  WindowPort.simulateMessageFromBackground({
+    action: Constants.WS_ACTION,
+    wsAction: Constants.EVENT_ACTION,
+    wsEvent: Constants.WS_EVENT_SENDERROR,
+    data: TEST_MESSAGE
+  });
+  assertEquals(true, called);
+  assertEquals(TEST_MESSAGE, message);
+};

--- a/src/web_app/js/signalingchannel_test.js
+++ b/src/web_app/js/signalingchannel_test.js
@@ -9,86 +9,13 @@
 /* More information about these options at jshint.com/docs/options */
 
 /* globals TestCase, assertEquals, assertNotNull, assertTrue, assertFalse,
-   WebSocket:true, XMLHttpRequest:true, SignalingChannel */
+   WebSocket:true, XMLHttpRequest:true, SignalingChannel, webSockets:true,
+   xhrs:true, FAKE_WSS_URL, FAKE_WSS_POST_URL, FAKE_ROOM_ID, FAKE_CLIENT_ID,
+   MockXMLHttpRequest, MockWebSocket */
 
 'use strict';
 
-var FAKE_WSS_URL = 'wss://foo.com';
-var FAKE_WSS_POST_URL = 'https://foo.com';
-var FAKE_ROOM_ID = 'bar';
-var FAKE_CLIENT_ID = 'barbar';
-
 var SignalingChannelTest = new TestCase('SignalingChannelTest');
-
-var webSockets = [];
-var MockWebSocket = function(url) {
-  assertEquals(FAKE_WSS_URL, url);
-
-  this.url = url;
-  this.messages = [];
-  this.readyState = WebSocket.CONNECTING;
-
-  this.onopen = null;
-  this.onclose = null;
-  this.onerror = null;
-  this.onmessage = null;
-
-  webSockets.push(this);
-};
-
-MockWebSocket.CONNECTING = WebSocket.CONNECTING;
-MockWebSocket.OPEN = WebSocket.OPEN;
-MockWebSocket.CLOSED = WebSocket.CLOSED;
-
-MockWebSocket.prototype.simulateOpenResult = function(success) {
-  if (success) {
-    this.readyState = WebSocket.OPEN;
-    if (this.onopen) {
-      this.onopen();
-    }
-  } else {
-    this.readyState = WebSocket.CLOSED;
-    if (this.onerror) {
-      this.onerror(Error('Mock open error'));
-    }
-  }
-};
-
-MockWebSocket.prototype.send = function(msg) {
-  if (this.readyState !== WebSocket.OPEN) {
-    throw 'Send called when the conneciton is not open';
-  }
-  this.messages.push(msg);
-};
-
-MockWebSocket.prototype.close = function() {
-  this.readyState = WebSocket.CLOSED;
-};
-
-var xhrs = [];
-var MockXMLHttpRequest = function() {
-  this.url = null;
-  this.method = null;
-  this.async = true;
-  this.body = null;
-  this.readyState = 0;
-
-  xhrs.push(this);
-};
-MockXMLHttpRequest.prototype.open = function(method, path, async) {
-  this.url = path;
-  this.method = method;
-  this.async = async;
-  this.readyState = 1;
-};
-MockXMLHttpRequest.prototype.send = function(body) {
-  this.body = body;
-  if (this.async) {
-    this.readyState = 2;
-  } else {
-    this.readyState = 4;
-  }
-};
 
 SignalingChannelTest.prototype.setUp = function() {
   webSockets = [];

--- a/src/web_app/js/test_mocks.js
+++ b/src/web_app/js/test_mocks.js
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+
+/* globals assertEquals */
+/* exported FAKE_WSS_POST_URL, FAKE_WSS_URL, FAKE_WSS_POST_URL, FAKE_ROOM_ID,
+   FAKE_CLIENT_ID, MockWebSocket, MockXMLHttpRequest, webSockets, xhrs,
+   MockWindowPort, FAKE_SEND_EXCEPTION */
+
+'use strict';
+
+var FAKE_WSS_URL = 'wss://foo.com';
+var FAKE_WSS_POST_URL = 'https://foo.com';
+var FAKE_ROOM_ID = 'bar';
+var FAKE_CLIENT_ID = 'barbar';
+var FAKE_SEND_EXCEPTION = 'Send exception';
+
+var webSockets = [];
+var MockWebSocket = function(url) {
+  assertEquals(FAKE_WSS_URL, url);
+
+  this.url = url;
+  this.messages = [];
+  this.readyState = WebSocket.CONNECTING;
+
+  this.onopen = null;
+  this.onclose = null;
+  this.onerror = null;
+  this.onmessage = null;
+
+  webSockets.push(this);
+};
+
+MockWebSocket.CONNECTING = WebSocket.CONNECTING;
+MockWebSocket.OPEN = WebSocket.OPEN;
+MockWebSocket.CLOSED = WebSocket.CLOSED;
+
+MockWebSocket.prototype.simulateOpenResult = function(success) {
+  if (success) {
+    this.readyState = WebSocket.OPEN;
+    if (this.onopen) {
+      this.onopen();
+    }
+  } else {
+    this.readyState = WebSocket.CLOSED;
+    if (this.onerror) {
+      this.onerror(Error('Mock open error'));
+    }
+  }
+};
+
+MockWebSocket.prototype.send = function(msg) {
+  if (this.readyState !== WebSocket.OPEN) {
+    throw 'Send called when the connection is not open';
+  }
+
+  if (this.throwOnSend) {
+    throw FAKE_SEND_EXCEPTION;
+  }
+
+  this.messages.push(msg);
+};
+
+MockWebSocket.prototype.close = function() {
+  this.readyState = WebSocket.CLOSED;
+};
+
+var xhrs = [];
+var MockXMLHttpRequest = function() {
+  this.url = null;
+  this.method = null;
+  this.async = true;
+  this.body = null;
+  this.readyState = 0;
+
+  xhrs.push(this);
+};
+MockXMLHttpRequest.prototype.open = function(method, path, async) {
+  this.url = path;
+  this.method = method;
+  this.async = async;
+  this.readyState = 1;
+};
+MockXMLHttpRequest.prototype.send = function(body) {
+  this.body = body;
+  if (this.async) {
+    this.readyState = 2;
+  } else {
+    this.readyState = 4;
+  }
+};
+
+var MockWindowPort = function() {
+  this.messages = [];
+  this.onMessage_ = null;
+};
+
+MockWindowPort.prototype.addMessageListener = function(callback) {
+  this.onMessage_ = callback;
+};
+
+MockWindowPort.prototype.sendMessage = function(message) {
+  this.messages.push(message);
+};
+
+MockWindowPort.prototype.simulateMessageFromBackground = function(message) {
+  if (this.onMessage_) {
+    this.onMessage_(message);
+  }
+};

--- a/src/web_app/js/testpolyfills.js
+++ b/src/web_app/js/testpolyfills.js
@@ -141,25 +141,41 @@ MyPromise.prototype.onReject_ = function(reason) {
 window.Promise = window.Promise || MyPromise;
 
 // Provide a shim for phantomjs, where chrome is not defined.
-var myChrome = {
-  app: {
-    runtime: {
-      onLaunched: {
-        addListener: function(callback) {
+var myChrome = (function() {
+  var onConnectCallback_;
+  return {
+    app: {
+      runtime: {
+        onLaunched: {
+          addListener: function(callback) {
+            console.log(
+                'chrome.app.runtime.onLaunched.addListener called:' + callback);
+          }
+        }
+      },
+      window: {
+        create: function(fileName, callback) {
           console.log(
-              'chrome.app.runtime.onLaunched.addListener called:' +
-               JSON.stringify(callback));
+              'chrome.window.create called: ' +
+              fileName + ', ' + callback);
         }
       }
     },
-    window: {
-      create: function(fileName, callback) {
-        console.log(
-            'chrome.window.create called: ' +
-            fileName + ', ' + JSON.stringify(callback));
+    runtime: {
+      onConnect: {
+        addListener: function(callback) {
+          console.log(
+              'chrome.runtime.onConnect.addListener called: ' + callback);
+          onConnectCallback_ = callback;
+        }
+      }
+    },
+    callOnConnect: function(port) {
+      if (onConnectCallback_) {
+        onConnectCallback_(port);
       }
     }
-  }
-};
+  };
+})();
 
 window.chrome = window.chrome || myChrome;

--- a/src/web_app/js/windowport.js
+++ b/src/web_app/js/windowport.js
@@ -9,7 +9,7 @@
 /* More information about these options at jshint.com/docs/options */
 
 /* globals trace, chrome */
-/* exported WindowPort */
+/* exported apprtc, apprtc.windowPort */
 
 'use strict';
 
@@ -17,10 +17,12 @@
 // It opens a Port object to send and receive messages. When the Chrome
 // App window is closed, background.js receives notification and can
 // handle clean up tasks.
-var WindowPort = (function() {
+var apprtc = apprtc || {};
+apprtc.windowPort = apprtc.windowPort || {};
+(function() {
   var port_;
 
-  var sendMessage = function(message) {
+  apprtc.windowPort.sendMessage = function(message) {
     var port = getPort_();
     try {
       port.postMessage(message);
@@ -30,7 +32,7 @@ var WindowPort = (function() {
     }
   };
 
-  var addMessageListener = function(listener) {
+  apprtc.windowPort.addMessageListener = function(listener) {
     var port = getPort_();
     port.onMessage.addListener(listener);
   };
@@ -40,10 +42,5 @@ var WindowPort = (function() {
       port_ = chrome.runtime.connect();
     }
     return port_;
-  };
-
-  return {
-    sendMessage: sendMessage,
-    addMessageListener: addMessageListener
   };
 })();

--- a/src/web_app/js/windowport.js
+++ b/src/web_app/js/windowport.js
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+
+/* globals trace, chrome */
+/* exported WindowPort */
+
+'use strict';
+
+// This is used to communicate from the Chrome App window to background.js.
+// It opens a Port object to send and receive messages. When the Chrome
+// App window is closed, background.js receives notification and can
+// handle clean up tasks.
+var WindowPort = (function() {
+  var port_;
+
+  var sendMessage = function(message) {
+    var port = getPort_();
+    try {
+      port.postMessage(message);
+    }
+    catch (ex) {
+      trace('Error sending message via port: ' + ex);
+    }
+  };
+
+  var addMessageListener = function(listener) {
+    var port = getPort_();
+    port.onMessage.addListener(listener);
+  };
+
+  var getPort_ = function() {
+    if (!port_) {
+      port_ = chrome.runtime.connect();
+    }
+    return port_;
+  };
+
+  return {
+    sendMessage: sendMessage,
+    addMessageListener: addMessageListener
+  };
+})();


### PR DESCRIPTION
Makes the following changes:
* Support both sync/async hangup flow. Sync is used when web browser closes so all cleanup calls can finish before browser closes, async is used when hang up button is pressed. Chrome App can't do sync xhr, so hang up flow has to be async.
* Moves websocket ownership to background.js in the Chrome App
* Adds a queue of cleanup actions in background.js that are executed when the Chrome App window closes

Only background.js knows when the app window closes, and once it has already closed, the window can no longer do xhr or web socket requests. Therefore, background.js has to take care of the clean up calls required to end the in progress call. 

@tkchin @jiayliu 

I'm still working to see if I can unit test more of the code, but wanted to send this out to get the review started, as it is a pretty complex bit of code.