### PR TITLE
Fix apiauth to insert third_party modules first.

### DIFF
--- a/src/app_engine/apiauth.py
+++ b/src/app_engine/apiauth.py
@@ -6,9 +6,10 @@ import json
 import os
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), 'third_party'))
+# Insert our third-party libraries first to avoid conflicts with appengine.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'third_party'))
 
-#from apiclient import discovery
+from apiclient import discovery
 import httplib2
 import oauth2client.appengine
 import oauth2client.client
@@ -18,22 +19,21 @@ import constants
 
 def build(scope, service_name, version):
   """Build a service object if authorization is available."""
-  return None
-# credentials = None
-# if constants.IS_DEV_SERVER:
-#   # Local instances require a 'secrets.json' file.
-#   secrets_path = os.path.join(os.path.dirname(__file__), 'secrets.json')
-#   if os.path.exists(secrets_path):
-#     with open(secrets_path) as f:
-#       auth = json.load(f)
-#       credentials = oauth2client.client.SignedJwtAssertionCredentials(
-#           auth['client_email'], auth['private_key'], scope)
-# else:
-#   # Use the GAE service credentials.
-#   credentials = oauth2client.appengine.AppAssertionCredentials(scope=scope)
+  credentials = None
+  if constants.IS_DEV_SERVER:
+    # Local instances require a 'secrets.json' file.
+    secrets_path = os.path.join(os.path.dirname(__file__), 'secrets.json')
+    if os.path.exists(secrets_path):
+      with open(secrets_path) as f:
+        auth = json.load(f)
+        credentials = oauth2client.client.SignedJwtAssertionCredentials(
+            auth['client_email'], auth['private_key'], scope)
+  else:
+    # Use the GAE service credentials.
+    credentials = oauth2client.appengine.AppAssertionCredentials(scope=scope)
 
-# if credentials is None:
-#   return None
+  if credentials is None:
+    return None
 
-# http = credentials.authorize(httplib2.Http())
-# return discovery.build(service_name, version, http=http)
+  http = credentials.authorize(httplib2.Http())
+  return discovery.build(service_name, version, http=http)


### PR DESCRIPTION
The new appengine sdk release added oauth2client of its own which was conflicting with ours. 