### PR TITLE
Use prober results to return working WS server.

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -115,18 +115,28 @@ def append_url_arguments(request, link):
   return link
 
 def get_wss_parameters(request):
-  ws_host_port_pair = request.get('wshpp')
-  ws_tls = request.get('wstls')
+  wss_host_port_pair = request.get('wshpp')
+  wss_tls = request.get('wstls')
 
-  if not ws_host_port_pair:
-    ws_host_port_pair = constants.WSS_HOST_PORT_PAIR
+  if not wss_host_port_pair:
+    # Attempt to get a wss server from the status provided by prober,
+    # if that fails, use fallback value.
+    memcache_client = memcache.Client()
+    wss_active_host = memcache_client.get(constants.WSS_HOST_ACTIVE_HOST_KEY)
+    if wss_active_host in constants.WSS_HOST_PORT_PAIRS:
+      wss_host_port_pair = wss_active_host
+    else:
+      logging.warning(
+          'Invalid or no value returned from memcache, using fallback: '
+          + json.dumps(wss_active_host))
+      wss_host_port_pair = constants.WSS_HOST_PORT_PAIRS[0]
 
-  if ws_tls and ws_tls == 'false':
-    wss_url = 'ws://' + ws_host_port_pair + '/ws'
-    wss_post_url = 'http://' + ws_host_port_pair
+  if wss_tls and wss_tls == 'false':
+    wss_url = 'ws://' + wss_host_port_pair + '/ws'
+    wss_post_url = 'http://' + wss_host_port_pair
   else:
-    wss_url = 'wss://' + ws_host_port_pair + '/ws'
-    wss_post_url = 'https://' + ws_host_port_pair
+    wss_url = 'wss://' + wss_host_port_pair + '/ws'
+    wss_post_url = 'https://' + wss_host_port_pair
   return (wss_url, wss_post_url)
 
 def get_version_info():

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -8,6 +8,7 @@ import json
 import os
 
 ROOM_MEMCACHE_EXPIRATION_SEC = 60 * 60 * 24
+MEMCACHE_RETRY_LIMIT = 100
 
 LOOPBACK_CLIENT_ID = 'LOOPBACK_CLIENT_ID'
 
@@ -15,7 +16,13 @@ TURN_BASE_URL = 'https://computeengineondemand.appspot.com'
 TURN_URL_TEMPLATE = '%s/turn?username=%s&key=%s'
 CEOD_KEY = '4080218913'
 
-WSS_HOST_PORT_PAIR = 'apprtc-ws.webrtc.org:443'
+WSS_HOST_PORT_PAIRS = ['apprtc-ws.webrtc.org:443', 'apprtc-ws-2.webrtc.org:443']
+WSS_HOST_ACTIVE_HOST_KEY = 'wss_host_active_host'
+
+WSS_HOST_INSTANCE_KEY = 'instance'
+WSS_HOST_IS_UP_KEY = 'is_up'
+WSS_HOST_STATUS_CODE_KEY = 'status_code'
+WSS_HOST_ERROR_MESSAGE_KEY = 'error_message'
 
 RESPONSE_ERROR = 'ERROR'
 RESPONSE_ROOM_FULL = 'FULL'

--- a/src/app_engine/cron.yaml
+++ b/src/app_engine/cron.yaml
@@ -1,8 +1,8 @@
 cron:
-- description: hourly CEOD probing job
+- description: CEOD probing job on 5 min interval
   url: /probe/ceod
-  schedule: every 1 hours synchronized
+  schedule: every 5 minutes synchronized
 
-- description: hourly collider probing job
+- description: collider probing job on 5 min interval
   url: /probe/collider
-  schedule: every 1 hours synchronized
+  schedule: every 5 minutes synchronized

--- a/src/app_engine/probers_test.py
+++ b/src/app_engine/probers_test.py
@@ -1,0 +1,97 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+
+import unittest
+
+import constants
+import probers
+
+from google.appengine.ext import testbed
+
+
+FAKE_ERROR_MESSAGE = 'SSL error'
+
+
+class ProbersTest(unittest.TestCase):
+  """Test the Probers class."""
+
+  def setUp(self):
+    # First, create an instance of the Testbed class.
+    self.testbed = testbed.Testbed()
+
+    # Then activate the testbed, which prepares the service stubs for use.
+    self.testbed.activate()
+
+  def tearDown(self):
+    pass
+
+  def verifyActiveHost(self, old_active_host, probing_results,
+                       possible_active_hosts):
+    new_active_host = probers.ProbeColliderPage().create_collider_active_host(
+        old_active_host,
+        probing_results)
+    self.assertIn(new_active_host, possible_active_hosts)
+
+  def createEntry(
+      self,
+      is_up,
+      status_code=None,
+      error_message=None):
+    result = {
+        constants.WSS_HOST_IS_UP_KEY: is_up
+    }
+    if status_code is not None:
+      result[constants.WSS_HOST_STATUS_CODE_KEY] = status_code
+    if error_message is not None:
+      result[constants.WSS_HOST_ERROR_MESSAGE_KEY] = error_message
+    return result
+
+  def testBuildColliderStatusEmpty(self):
+    probing_results = {
+        'serverC': self.createEntry(False, 500, FAKE_ERROR_MESSAGE),
+        'server3': self.createEntry(True),
+        'serverQ': self.createEntry(True),
+    }
+
+    old_active_host = None
+    possible_active_hosts = ['server3', 'serverQ']
+    self.verifyActiveHost(old_active_host, probing_results,
+                          possible_active_hosts)
+
+  def testBuildColliderNoHostsUp(self):
+    probing_results = {
+        'serverC': self.createEntry(False, 500, FAKE_ERROR_MESSAGE),
+        'server3': self.createEntry(False),
+        'serverQ': self.createEntry(False),
+    }
+
+    old_active_host = None
+    possible_active_hosts = [None]
+    self.verifyActiveHost(old_active_host, probing_results,
+                          possible_active_hosts)
+
+    old_active_host = 'serverC'
+    possible_active_hosts = [None]
+    self.verifyActiveHost(old_active_host, probing_results,
+                          possible_active_hosts)
+
+  def testBuildColliderStatus(self):
+    probing_results = {
+        'server3': self.createEntry(True),
+        'serverC': self.createEntry(False, 500, FAKE_ERROR_MESSAGE),
+        'serverD': self.createEntry(False, 500, FAKE_ERROR_MESSAGE),
+        'server2': self.createEntry(True),
+        'serverE': self.createEntry(True),
+        'server1': self.createEntry(False, 500, FAKE_ERROR_MESSAGE),
+        'serverA': self.createEntry(False, 500, FAKE_ERROR_MESSAGE),
+        'serverB': self.createEntry(True),
+    }
+
+    old_active_host = 'serverE'
+    possible_active_hosts = ['serverE']
+    self.verifyActiveHost(old_active_host, probing_results,
+                          possible_active_hosts)
+
+    old_active_host = 'server1'
+    possible_active_hosts = ['server3', 'server2', 'serverE', 'serverB']
+    self.verifyActiveHost(old_active_host, probing_results,
+                          possible_active_hosts)


### PR DESCRIPTION
This implements a simple strategy of returning whichever collider instance has been up the longest.

For example, assume we have servers A and B which are both up, and GAE is returning A
If A is reported as down by prober, GAE will start returning B. GAE will continue serving B even if A comes back up. B will returned until B if reported as down by problem.

This will help avoid the situation where clients within a room are in different collider instances. It does not get us any load balancing benefits. 

If we want to do something more advanced here to ensure clients get into the right collider instance together, the next steps would be:
1. When the first client joins a room, store the collider instance assigned to the client along with the room data.
2. When the second client joins a room, ensure we return that same collider instance.
3. Client would need to be updated to reconnect to the socket if the wss address returned by /join is different than the one it started with.

The situation this would prevent would be:
GAE is currently returning A,
Client 2 loads /, gets A in the initial params
A goes down, B is now returned
Client 1 loads 1/, gets B, joins room, gets assigned B, connects to B
Client 2 now joins a room, but connects to A because we connect before /join. When join returns B, client 2 needs to disconnect from A (possibly failed anyway) and connect to B.

I suspect the effort for the more advanced tracking/reconnecting is not worth it at this time.

@jiayliu @tkchin 