### PR TITLE
remove createIceServers

### DIFF
--- a/src/web_app/js/util.js
+++ b/src/web_app/js/util.js
@@ -93,12 +93,11 @@ function requestTurnServers(turnRequestUrl, turnTransports) {
       }
 
       // Create the RTCIceServer objects from the response.
-      var turnServers = createIceServers(turnServerResponse.uris,
-          turnServerResponse.username, turnServerResponse.password);
-      if (!turnServers) {
-        reject(Error('Error creating ICE servers from response.'));
-        return;
-      }
+      var turnServers = {
+        urls: turnServerResponse.uris,
+        username: turnServerResponse.username,
+        credential: turnServerResponse.password
+      };
       trace('Retrieved TURN server information.');
       resolve(turnServers);
     }).catch(function(error) {


### PR DESCRIPTION
depends on https://github.com/webrtc/adapter/pull/18 -- I can bump it here if desired.

Looks like the thing that vends nonces needs a terminology update as well (uris->urls, password->credential).
One step at a time...