### PR TITLE
Stringify for RTCSessionDescription

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -10,7 +10,7 @@
 
 /* globals trace, requestTurnServers, sendUrlRequest, sendAsyncUrlRequest,
    requestUserMedia, SignalingChannel, PeerConnectionClient, setupLoopback,
-   parseJSON, isChromeApp, apprtc, Constants, stringifyObject */
+   parseJSON, isChromeApp, apprtc, Constants, stringifyDOMObject */
 
 /* exported Call */
 
@@ -487,7 +487,7 @@ Call.prototype.onRecvSignalingChannelMessage_ = function(msg) {
 };
 
 Call.prototype.sendSignalingMessage_ = function(message) {
-  var msgString = stringifyObject(message);
+  var msgString = stringifyDOMObject(message);
   if (this.params_.isInitiator) {
     // Initiator posts all messages to GAE. GAE will either store the messages
     // until the other client connects, or forward the message to Collider if

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -10,7 +10,7 @@
 
 /* globals trace, requestTurnServers, sendUrlRequest, sendAsyncUrlRequest,
    requestUserMedia, SignalingChannel, PeerConnectionClient, setupLoopback,
-   parseJSON, isChromeApp, apprtc, Constants, stringifyDOMObject */
+   parseJSON, isChromeApp, apprtc, Constants */
 
 /* exported Call */
 
@@ -487,7 +487,7 @@ Call.prototype.onRecvSignalingChannelMessage_ = function(msg) {
 };
 
 Call.prototype.sendSignalingMessage_ = function(message) {
-  var msgString = stringifyDOMObject(message);
+  var msgString = JSON.stringify(message);
   if (this.params_.isInitiator) {
     // Initiator posts all messages to GAE. GAE will either store the messages
     // until the other client connects, or forward the message to Collider if

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -198,7 +198,14 @@ PeerConnectionClient.prototype.setLocalSdpAndNotify_ =
       this.onError_.bind(this, 'setLocalDescription'));
 
   if (this.onsignalingmessage) {
-    this.onsignalingmessage(sessionDescription);
+    // Chrome version of RTCSessionDescription can't be serialized directly
+    // because it JSON.stringify won't include attributes which are on the
+    // object's prototype chain. By creating the message to serialize explicitly
+    // we can avoid the issue.
+    this.onsignalingmessage({
+      sdp: sessionDescription.sdp,
+      type: sessionDescription.type
+    });
   }
 };
 

--- a/src/web_app/js/util.js
+++ b/src/web_app/js/util.js
@@ -10,7 +10,7 @@
 
 /* exported setUpFullScreen, fullScreenElement, isFullScreen,
    requestTurnServers, sendAsyncUrlRequest, sendSyncUrlRequest, randomString, $,
-   queryStringToDictionary, stringifyObject */
+   queryStringToDictionary, stringifyDOMObject */
 /* globals chrome */
 
 'use strict';
@@ -118,11 +118,10 @@ function parseJSON(json) {
   return null;
 }
 
-// Stringifies an object.  This function stringifies not only own properties
-// but also attributes which are on a prototype chain.  Note that
+// Stringifies a DOM object.  This function stringifies not only own properties
+// but also DOM attributes which are on a prototype chain.  Note that
 // JSON.stringify only stringifies own properties.
-// This is needed to stringify RTCSessionDescription objects for SDP.
-function stringifyObject(object) {
+function stringifyDOMObject(object) {
   function deepCopy(src) {
     if (typeof src !== 'object') {
       return src;

--- a/src/web_app/js/util.js
+++ b/src/web_app/js/util.js
@@ -10,7 +10,7 @@
 
 /* exported setUpFullScreen, fullScreenElement, isFullScreen,
    requestTurnServers, sendAsyncUrlRequest, sendSyncUrlRequest, randomString, $,
-   queryStringToDictionary, stringifyDOMObject */
+   queryStringToDictionary */
 /* globals chrome */
 
 'use strict';
@@ -116,23 +116,6 @@ function parseJSON(json) {
     trace('Error parsing json: ' + json);
   }
   return null;
-}
-
-// Stringifies a DOM object.  This function stringifies not only own properties
-// but also DOM attributes which are on a prototype chain.  Note that
-// JSON.stringify only stringifies own properties.
-function stringifyDOMObject(object) {
-  function deepCopy(src) {
-    if (typeof src !== 'object') {
-      return src;
-    }
-    var dst = Array.isArray(src) ? [] : {};
-    for (var property in src) {
-      dst[property] = deepCopy(src[property]);
-    }
-    return dst;
-  }
-  return JSON.stringify(deepCopy(object));
 }
 
 // Filter a list of TURN urls to only contain those with transport=|protocol|.


### PR DESCRIPTION
This reverts the original fix which worked for Chrome but not Firefox, and makes a simpler change which should work both places.

https://github.com/webrtc/apprtc/issues/122

Firefox's mozRTCSessionDescription includes a toJSON function, probably to solve this exact problem, when the object was copied, the toJSON function was copied as well, and then JSON.stringify called that function. The function checks the object type and throws an error when it isn't the correct type.

Rather than put in more special cases, this change creates the message to send by making a simple copy of the properties we care about.

We could also investigate getting a toJSON added to the Chrome implementation.

@jiayliu @tkchin 