### PR TITLE
add a flow id to the analytics system

### DIFF
--- a/src/app_engine/analytics.py
+++ b/src/app_engine/analytics.py
@@ -58,6 +58,7 @@ class Analytics(object):
       client_time_ms: Time that an event occurred on the client, if the event
                       originated on the client.
       host: Hostname this is being logged on.
+      flow_id: ID to group a set of events together.
     """
     # Be forgiving. If an event is a string or is an unknown number we
     # still log it but log it as the string value.

--- a/src/app_engine/analytics.py
+++ b/src/app_engine/analytics.py
@@ -47,7 +47,7 @@ class Analytics(object):
     return datetime.datetime.fromtimestamp(float(time_ms)/1000.).isoformat()
 
   def report_event(self, event_type, room_id=None, time_ms=None,
-                   client_time_ms=None, host=None):
+                   client_time_ms=None, host=None, flow_id=None):
     """Report an event to BigQuery.
 
     Args:
@@ -66,6 +66,9 @@ class Analytics(object):
 
     if room_id is not None:
       event[LogField.ROOM_ID] = room_id
+
+    if flow_id is not None:
+      event[LogField.FLOW_ID] = flow_id
 
     if client_time_ms is not None:
       event[LogField.CLIENT_TIMESTAMP] = self._timestamp_from_millis(

--- a/src/app_engine/analytics_page.py
+++ b/src/app_engine/analytics_page.py
@@ -95,6 +95,7 @@ class AnalyticsPage(webapp2.RequestHandler):
       return constants.RESPONSE_INVALID_REQUEST
 
     room_id = event.get(RequestField.EventField.ROOM_ID)
+    flow_id = event.get(RequestField.EventField.FLOW_ID)
 
     # Time that the event occurred according to the client clock.
     try:
@@ -123,6 +124,7 @@ class AnalyticsPage(webapp2.RequestHandler):
                            room_id=room_id,
                            time_ms=event_time_ms,
                            client_time_ms=client_event_time_ms,
-                           host=self.request.host)
+                           host=self.request.host,
+                           flow_id=flow_id)
 
     return constants.RESPONSE_SUCCESS

--- a/src/app_engine/analytics_page_test.py
+++ b/src/app_engine/analytics_page_test.py
@@ -67,6 +67,7 @@ class AnalyticsPageHandlerTest(unittest.TestCase):
     host = 'localhost:80'
 
     room_id = 'foo'
+    flow_id = 1337
     event_type = analytics.EventType.ICE_CONNECTION_STATE_CONNECTED
 
     # Test with all optional attributes.
@@ -77,6 +78,7 @@ class AnalyticsPageHandlerTest(unittest.TestCase):
             RequestField.EventField.EVENT_TYPE: event_type,
             RequestField.EventField.EVENT_TIME_MS: event_time_ms,
             RequestField.EventField.ROOM_ID: room_id,
+            RequestField.EventField.FLOW_ID: flow_id,
             }
         }
 
@@ -89,7 +91,8 @@ class AnalyticsPageHandlerTest(unittest.TestCase):
                            room_id=room_id,
                            time_ms=event_time_server_ms,
                            client_time_ms=event_time_ms,
-                           host=host)
+                           host=host,
+                           flow_id=flow_id,)
     self.assertEqual(expected_kwargs, analytics.report_event.last_kwargs)
 
     # Test without optional attributes.
@@ -111,7 +114,8 @@ class AnalyticsPageHandlerTest(unittest.TestCase):
                            room_id=None,
                            time_ms=event_time_server_ms,
                            client_time_ms=event_time_ms,
-                           host=host)
+                           host=host,
+                           flow_id=None)
 
     self.assertEqual(expected_kwargs, analytics.report_event.last_kwargs)
 

--- a/src/app_engine/analytics_test.py
+++ b/src/app_engine/analytics_test.py
@@ -138,6 +138,7 @@ class AnalyticsTest(unittest.TestCase):
     time_s = self.now + 50
     client_time_s = self.now + 60
     host = 'super_host.domain.org:8112'
+    flow_id = 31337
 
     log_dict = self.create_log_dict({
         LogField.TIMESTAMP: '{0}'.format(
@@ -146,14 +147,16 @@ class AnalyticsTest(unittest.TestCase):
         LogField.ROOM_ID: room_id,
         LogField.CLIENT_TIMESTAMP: '{0}'.format(
             datetime.datetime.fromtimestamp(client_time_s).isoformat()),
-        LogField.HOST: host
+        LogField.HOST: host,
+        LogField.FLOW_ID: flow_id,
     })
 
     self.tics.report_event(event_type,
                            room_id=room_id,
                            time_ms=time_s*1000.,
                            client_time_ms=client_time_s*1000.,
-                           host=host)
+                           host=host,
+                           flow_id=flow_id)
     self.assertEqual(log_dict, self.bigquery.insertAll.last_kwargs)
 
 

--- a/src/app_engine/bigquery/analytics_schema.json
+++ b/src/app_engine/bigquery/analytics_schema.json
@@ -23,5 +23,10 @@
     "name": "host",
     "type": "string",
     "mode": "nullable"
+  },
+  {
+    "name": "flow_id",
+    "type": "integer",
+    "mode": "nullable"
   }
 ]

--- a/src/app_engine/bigquery/enums.json
+++ b/src/app_engine/bigquery/enums.json
@@ -16,7 +16,8 @@
     "EventField": {
       "EVENT_TYPE": "event_type",
       "ROOM_ID": "room_id",
-      "EVENT_TIME_MS": "event_time_ms"
+      "EVENT_TIME_MS": "event_time_ms",
+      "FLOW_ID": "flow_id"
     }
   }
 }


### PR DESCRIPTION
specifying a flow id for a set of events can group them together and
enables calculation client performance.