### PR TITLE
adding opusdtx in parameters

### DIFF
--- a/src/web_app/html/params.html
+++ b/src/web_app/html/params.html
@@ -82,6 +82,9 @@
         <tr><td><a href="https://apprtc.appspot.com?asbr=16000">asbr=[bitrate]</a></td><td>Set audio send bitrate</td></tr>
         <tr><td><a href="https://apprtc.appspot.com?vsbr=1000">vsbr=[bitrate]</a></td><td>Set video receive bitrate</td></tr>
         <tr><td><a href="https://apprtc.appspot.com?vrbr=8000">vrbr=[bitrate]</a></td><td>Set video send bitrate</td></tr>
+        <tr><td><a href="https://apprtc.appspot.com?opusfec=false">opusfec=false</a></td><td>Turn off Opus FEC</td></tr>
+        <tr><td><a href="https://apprtc.appspot.com?opusdtx=true">opusdtx=true</a></td><td>Turn on Opus DTX</td></tr>
+        <tr><td><a href="https://apprtc.appspot.com?opusmaxpbr=8000">opusmaxpbr=8000</a></td><td>Set the maximum sample rate that the receiver can operate, for optimal Opus encoding performance</td></tr>
       </table>
 
     </section>

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -494,6 +494,7 @@ AppController.prototype.loadUrlParams_ = function() {
   this.loadingParams_.audioRecvCodec = urlParams['arc'];
   this.loadingParams_.opusMaxPbr = urlParams['opusmaxpbr'];
   this.loadingParams_.opusFec = urlParams['opusfec'];
+  this.loadingParams_.opusDtx = urlParams['opusdtx'];
   this.loadingParams_.opusStereo = urlParams['stereo'];
   this.loadingParams_.videoSendBitrate = urlParams['vsbr'];
   this.loadingParams_.videoSendInitialBitrate = urlParams['vsibr'];

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -51,6 +51,14 @@ function maybeSetOpusOptions(sdp, params) {
     sdp = removeCodecParam(sdp, 'opus/48000', 'useinbandfec');
   }
 
+  // Set Opus DTX, if opusdtx is true, unset it, if opusdtx is false, and
+  // do nothing if otherwise.
+  if (params.opusDtx === 'true') {
+    sdp = setCodecParam(sdp, 'opus/48000', 'usedtx', '1');
+  } else if (params.opusDtx === 'false') {
+    sdp = removeCodecParam(sdp, 'opus/48000', 'usedtx');
+  }
+
   // Set Opus maxplaybackrate, if requested.
   if (params.opusMaxPbr) {
     sdp = setCodecParam(


### PR DESCRIPTION
This is to add "usedtx=1" to the fmtp line about Opus codec, when "opusdtx=true" in URL. This gives an easy way to enable Opus DTX.