### PR TITLE
Client_type is now reported as a string.

### DIFF
--- a/src/app_engine/analytics.py
+++ b/src/app_engine/analytics.py
@@ -10,7 +10,7 @@ import time
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'third_party'))
 
-from analytics_enums import EventType, LogField
+from analytics_enums import EventType, LogField, ClientType
 import apiauth
 import constants
 
@@ -75,7 +75,8 @@ class Analytics(object):
       event[LogField.FLOW_ID] = flow_id
 
     if client_type is not None:
-      event[LogField.CLIENT_TYPE] = client_type
+      client_type_name = ClientType.Name.get(client_type, str(client_type))
+      event[LogField.CLIENT_TYPE] = client_type_name
 
     if client_time_ms is not None:
       event[LogField.CLIENT_TIMESTAMP] = self._timestamp_from_millis(

--- a/src/app_engine/analytics_test.py
+++ b/src/app_engine/analytics_test.py
@@ -1,11 +1,15 @@
 # Copyright 2014 Google Inc. All Rights Reserved.
 
 import datetime
+import json
+import os
 import time
 import unittest
 
 import analytics
-from analytics_enums import EventType, LogField
+from analytics_enums import EventType
+from analytics_enums import LogField
+from analytics_enums import ClientType
 from test_util import CapturingFunction
 from test_util import ReplaceFunction
 
@@ -24,6 +28,13 @@ class FakeBigQuery(object):
 
 class AnalyticsTest(unittest.TestCase):
   """Test the Analytics class in the analytics module."""
+
+  # Maps from a BigQuery type to Python type.
+  BQ_TYPE_MAP = {
+      'string': [str, unicode],
+      'integer': [int, long],
+      'timestamp': [str],
+  }
 
   def fake_build_bigquery_object(self, *_):
     self.bigquery = FakeBigQuery()
@@ -58,10 +69,30 @@ class AnalyticsTest(unittest.TestCase):
     # Instanciate an instance.
     self.tics = analytics.Analytics()
 
+    bqschema = json.load(open(os.path.join(os.path.dirname(__file__),
+                                           'bigquery',
+                                           'analytics_schema.json')))
+    self.bq_field_type = {}
+    for field in bqschema:
+      self.bq_field_type[field['name']] = self.BQ_TYPE_MAP[field['type']]
+
   def tearDown(self):
     # Cleanup our replacement functions.
     del self.time_replacement
     del self.build_big_query_replacement
+
+  def assertOneOf(self, inst, group):
+    if inst not in group:
+      raise AssertionError('%s is not a member of %s' % (inst, group))
+
+  def check_bigquery_types(self, entry):
+    log_data = entry['body']['rows'][0]['json']
+    for field, value in log_data.iteritems():
+      self.assertOneOf(type(value), self.bq_field_type[field])
+
+  def validateBigQueryEntry(self, expected, actual):
+    self.assertEqual(expected, actual)
+    self.check_bigquery_types(actual)
 
   def testEventAsString(self):
     event_type = 'an_event_with_everything'
@@ -85,7 +116,7 @@ class AnalyticsTest(unittest.TestCase):
                            time_ms=time_s*1000.,
                            client_time_ms=client_time_s*1000.,
                            host=host)
-    self.assertEqual(log_dict, self.bigquery.insertAll.last_kwargs)
+    self.validateBigQueryEntry(log_dict, self.bigquery.insertAll.last_kwargs)
 
   def testUnknowEventNumber(self):
     event_type = -1  # Numbers for events should never be negative.
@@ -109,7 +140,7 @@ class AnalyticsTest(unittest.TestCase):
                            time_ms=time_s*1000.,
                            client_time_ms=client_time_s*1000.,
                            host=host)
-    self.assertEqual(log_dict, self.bigquery.insertAll.last_kwargs)
+    self.validateBigQueryEntry(log_dict, self.bigquery.insertAll.last_kwargs)
 
   def testOnlyEvent(self):
     event_type = EventType.ROOM_SIZE_2
@@ -118,7 +149,7 @@ class AnalyticsTest(unittest.TestCase):
          LogField.EVENT_TYPE: EventType.Name[event_type]})
 
     self.tics.report_event(event_type)
-    self.assertEqual(log_dict, self.bigquery.insertAll.last_kwargs)
+    self.validateBigQueryEntry(log_dict, self.bigquery.insertAll.last_kwargs)
 
   def testEventRoom(self):
     event_type = EventType.ROOM_SIZE_2
@@ -130,17 +161,19 @@ class AnalyticsTest(unittest.TestCase):
     })
 
     self.tics.report_event(event_type, room_id=room_id)
-    self.assertEqual(log_dict, self.bigquery.insertAll.last_kwargs)
+    self.validateBigQueryEntry(log_dict, self.bigquery.insertAll.last_kwargs)
 
   def testEventAll(self):
+    # Events as they will be reported.
     event_type = EventType.ROOM_SIZE_2
     room_id = 'my_room_that_is_the_best'
     time_s = self.now + 50
     client_time_s = self.now + 60
     host = 'super_host.domain.org:8112'
     flow_id = 31337
-    client_type = 'android_on_ios'
+    client_type = ClientType.ANDROID
 
+    # How the log entries should appear in the logs.
     log_dict = self.create_log_dict({
         LogField.TIMESTAMP: '{0}'.format(
             datetime.datetime.fromtimestamp(time_s).isoformat()),
@@ -150,7 +183,7 @@ class AnalyticsTest(unittest.TestCase):
             datetime.datetime.fromtimestamp(client_time_s).isoformat()),
         LogField.HOST: host,
         LogField.FLOW_ID: flow_id,
-        LogField.CLIENT_TYPE: client_type,
+        LogField.CLIENT_TYPE: ClientType.Name[client_type],
     })
 
     self.tics.report_event(event_type,
@@ -160,7 +193,7 @@ class AnalyticsTest(unittest.TestCase):
                            host=host,
                            flow_id=flow_id,
                            client_type=client_type)
-    self.assertEqual(log_dict, self.bigquery.insertAll.last_kwargs)
+    self.validateBigQueryEntry(log_dict, self.bigquery.insertAll.last_kwargs)
 
 
 class AnalyticsModuleTest(unittest.TestCase):


### PR DESCRIPTION
client_Type is passed to the analytics module as a number. It needs to
be converted to a string to be a valid BigQuery entry.

Adds some additional checking in the Analytics unittest code to validate
BigQuery types in the tests. This should catch this type of bug in the future.

Fixes #139