### PR TITLE
Add verbose option phantomJS to see all test executions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
       genJsEnums: {
         command: ['python', './build/gen_js_enums.py', 'src',
                   'src/web_app/js'].join(' ')
-      },
+      }
     },
 
     'grunt-chrome-build' : {
@@ -128,25 +128,27 @@ module.exports = function(grunt) {
             ],
             dest: 'out/chrome_app/'
           }
-        ],
+        ]
       }
     },
 
     jstdPhantom: {
       options: {
+        verbose: true,
         useLatest : true,
-        port: 9876,
+        port: 9876
       },
       files: [
-        'build/js_test_driver.conf',
-      ]},
+        'build/js_test_driver.conf'
+      ]
+    },
 
     closurecompiler: {
       debug: {
         files: {
           // Destination: [source files]
           'out/app_engine/js/apprtc.debug.js': [
-	    'src/web_app/js/analytics.js',
+            'src/web_app/js/analytics.js',
             'src/web_app/js/enums.js',
             'src/web_app/js/adapter.js',
             'src/web_app/js/appcontroller.js',
@@ -161,16 +163,16 @@ module.exports = function(grunt) {
             'src/web_app/js/stats.js',
             'src/web_app/js/storage.js',
             'src/web_app/js/util.js',
-            'src/web_app/js/windowport.js',
+            'src/web_app/js/windowport.js'
           ]
         },
         options: {
           'compilation_level': 'WHITESPACE_ONLY',
           'language_in': 'ECMASCRIPT5',
           'formatting': 'PRETTY_PRINT'
-        },
-      },
-    },
+        }
+      }
+    }
   });
 
   // Enable plugins.

--- a/build/grunt-chrome-build/grunt-chrome-build.js
+++ b/build/grunt-chrome-build/grunt-chrome-build.js
@@ -13,12 +13,11 @@ module.exports = function (grunt) {
     // Steps:
     // 1. Delete existing build dir if it exists.
     var buildDir = options.buildDir;
-    if (!buildDir) {
-      throw grunt.util.error('Missing required buildDir option.');
+    if (grunt.file.isDir(buildDir)) {
+      grunt.log.writeln('Deleting buildDir: ' + buildDir);
+      grunt.file.delete(buildDir);
     }
-    grunt.log.writeln('Deleting buildDir: ' + buildDir);
-    grunt.file.delete(buildDir);
-
+    
     // 2. Create build dir.
     grunt.log.writeln('Creating empty buildDir: ' + buildDir);
     grunt.file.mkdir(buildDir);

--- a/src/web_app/js/utils_test.js
+++ b/src/web_app/js/utils_test.js
@@ -73,7 +73,7 @@ UtilsTest.prototype.testQueryStringToDictionary = function() {
     'foo': 'a',
     'baz': '',
     'bar': 'b',
-    'tee': '',
+    'tee': ''
   };
 
   var buildQuery = function(data, includeEqualsOnEmpty) {


### PR DESCRIPTION
* Remove uneccessary error when build dir does not exist
* General cleanup of tab characters and uneccesary colons
* Add verbose option phantomJS to see all test executions
* I wanted to try to figure out why phantomJS throws an error, while doing so I found some small nits that makes up this pull request. Have not figured out why phantomJS throws the error though, seems like something causes it to exit uncleanly. Will continue in a seperate PR.


The error that I'm writing about:
>Total 63 tests (Passed: 63; Fails: 0; Errors: 0) (287.00 ms)
  Safari 534.34 Linux: Run 63 tests (Passed: 63; Fails: 0; Errors 0) (287.00 ms)
>> Finished running file: build/js_test_driver.conf


>> Total Passed: 63, Fails: 0
Error
PhantomJS threw an error:
Done, without errors.
