### PR TITLE
Don't crash when `ts` parameter is empty string

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -248,6 +248,8 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   if len(turn_base_url) > 0:
     turn_url = constants.TURN_URL_TEMPLATE % \
         (turn_base_url, username, constants.CEOD_KEY)
+  else:
+    turn_url = ''
 
   pc_config = make_pc_config(ice_transports)
   pc_constraints = make_pc_constraints(dtls, dscp, ipv6)


### PR DESCRIPTION
Passing empty string for `ts` parameter causes the server to crash.

For example, `curl http://localhost/params?ts=` will crash the server with the following error:

    ERROR    2015-07-08 13:14:01,145 webapp2.py:1528] local variable 'turn_url' referenced before assignment
    Traceback (most recent call last):
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1511, in __call__
        rv = self.handle_exception(request, response, e)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1505, in __call__
        rv = self.router.dispatch(request, response)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1253, in default_dispatcher
        return route.handler_adapter(request, response)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1077, in __call__
        return handler.dispatch()
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 547, in dispatch
        return self.handle_exception(e, self.app.debug)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 545, in dispatch
        return method(*args, **kwargs)
      File "/home/monster_strike/apprtc/out/app_engine/apprtc.py", line 559, in get
        params = get_room_parameters(self.request, None, None, None)
      File "/home/monster_strike/apprtc/out/app_engine/apprtc.py", line 269, in get_room_parameters
        'turn_url': turn_url,
    UnboundLocalError: local variable 'turn_url' referenced before assignment
    ERROR    2015-07-08 13:14:01,146 wsgi.py:279]
    Traceback (most recent call last):
      File "/home/monster_strike/google_appengine/google/appengine/runtime/wsgi.py", line 267, in Handle
        result = handler(dict(self._environ), self._StartResponse)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1519, in __call__
        response = self._internal_error(e)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1511, in __call__
        rv = self.handle_exception(request, response, e)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1505, in __call__
        rv = self.router.dispatch(request, response)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1253, in default_dispatcher
        return route.handler_adapter(request, response)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 1077, in __call__
        return handler.dispatch()
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 547, in dispatch
        return self.handle_exception(e, self.app.debug)
      File "/home/monster_strike/google_appengine/lib/webapp2-2.3/webapp2.py", line 545, in dispatch
        return method(*args, **kwargs)
      File "/home/monster_strike/apprtc/out/app_engine/apprtc.py", line 559, in get
        params = get_room_parameters(self.request, None, None, None)
      File "/home/monster_strike/apprtc/out/app_engine/apprtc.py", line 269, in get_room_parameters
        'turn_url': turn_url,
    UnboundLocalError: local variable 'turn_url' referenced before assignment
    INFO     2015-07-08 13:14:01,152 module.py:812] default: "GET /params?ts= HTTP/1.1" 500 -

This PR fixes the crash.
