### PR TITLE
Fixed jscs and jshint errors, imported adapter.js 0.1.9

### DIFF
--- a/build/.jshintrc
+++ b/build/.jshintrc
@@ -23,6 +23,7 @@
     "createIceServers": true,
     "createIceServer": true,
     "createLineChart": true,
+    "define": true,
     "doGetUserMedia": true,
     "expectEquals": true,
     "getUserMedia": true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Project checking for AppRTC repo",
   "main": "Gruntfile.js",
   "scripts": {
+    "postinstall": "cp node_modules/webrtc-adapter-test/adapter.js src/web_app/js/",
     "test": "grunt --verbose"
   },
   "devDependencies": {
@@ -17,6 +18,7 @@
     "grunt-jscs": ">=0.8.1",
     "grunt-shell": "^1.1.1",
     "grunt-jstestdriver-phantomjs": ">=0.0.7",
-    "grunt-closurecompiler": ">=0.0.21"
+    "grunt-closurecompiler": ">=0.0.21",
+    "webrtc-adapter-test": "^0.1.0"
   }
 }

--- a/src/web_app/js/adapter.js
+++ b/src/web_app/js/adapter.js
@@ -22,6 +22,15 @@ var reattachMediaStream = null;
 var webrtcDetectedBrowser = null;
 var webrtcDetectedVersion = null;
 var webrtcMinimumVersion = null;
+var webrtcUtils = {
+  log: function() {
+    // suppress console.log output when being included as a module.
+    if (!(typeof module !== 'undefined' ||
+        typeof require === 'function') && (typeof define === 'function')) {
+      console.log.apply(console, arguments);
+    }
+  }
+};
 
 function trace(text) {
   // This function is used for logging.
@@ -30,14 +39,17 @@ function trace(text) {
   }
   if (window.performance) {
     var now = (window.performance.now() / 1000).toFixed(3);
-    console.log(now + ': ' + text);
+    webrtcUtils.log(now + ': ' + text);
   } else {
-    console.log(text);
+    webrtcUtils.log(text);
   }
 }
 
-if (navigator.mozGetUserMedia) {
-  console.log('This appears to be Firefox');
+if (typeof window === 'undefined' || !window.navigator) {
+  webrtcUtils.log('This does not appear to be a browser');
+  webrtcDetectedBrowser = 'not a browser';
+} else if (navigator.mozGetUserMedia) {
+  webrtcUtils.log('This appears to be Firefox');
 
   webrtcDetectedBrowser = 'firefox';
 
@@ -75,7 +87,7 @@ if (navigator.mozGetUserMedia) {
         pcConfig.iceServers = newIceServers;
       }
     }
-    return new mozRTCPeerConnection(pcConfig, pcConstraints);
+    return new mozRTCPeerConnection(pcConfig, pcConstraints); // jscs:ignore requireCapitalizedConstructors
   };
 
   // The RTCSessionDescription object.
@@ -85,27 +97,38 @@ if (navigator.mozGetUserMedia) {
   window.RTCIceCandidate = mozRTCIceCandidate;
 
   // getUserMedia constraints shim.
-  getUserMedia = (webrtcDetectedVersion < 38) ?
-      function(c, onSuccess, onError) {
+  getUserMedia = function(constraints, onSuccess, onError) {
     var constraintsToFF37 = function(c) {
       if (typeof c !== 'object' || c.require) {
         return c;
       }
       var require = [];
       Object.keys(c).forEach(function(key) {
+        if (key === 'require' || key === 'advanced' || key === 'mediaSource') {
+          return;
+        }
         var r = c[key] = (typeof c[key] === 'object') ?
             c[key] : {ideal: c[key]};
-        if (r.exact !== undefined) {
-          r.min = r.max = r.exact;
-          delete r.exact;
-        }
-        if (r.min !== undefined || r.max !== undefined) {
+        if (r.min !== undefined ||
+            r.max !== undefined || r.exact !== undefined) {
           require.push(key);
+        }
+        if (r.exact !== undefined) {
+          if (typeof r.exact === 'number') {
+            r.min = r.max = r.exact;
+          } else {
+            c[key] = r.exact;
+          }
+          delete r.exact;
         }
         if (r.ideal !== undefined) {
           c.advanced = c.advanced || [];
           var oc = {};
-          oc[key] = {min: r.ideal, max: r.ideal};
+          if (typeof r.ideal === 'number') {
+            oc[key] = {min: r.ideal, max: r.ideal};
+          } else {
+            oc[key] = r.ideal;
+          }
           c.advanced.push(oc);
           delete r.ideal;
           if (!Object.keys(r).length) {
@@ -118,29 +141,39 @@ if (navigator.mozGetUserMedia) {
       }
       return c;
     };
-    console.log('spec: ' + JSON.stringify(c));
-    c.audio = constraintsToFF37(c.audio);
-    c.video = constraintsToFF37(c.video);
-    console.log('ff37: ' + JSON.stringify(c));
-    return navigator.mozGetUserMedia(c, onSuccess, onError);
-  } : navigator.mozGetUserMedia.bind(navigator);
+    if (webrtcDetectedVersion < 38) {
+      webrtcUtils.log('spec: ' + JSON.stringify(constraints));
+      if (constraints.audio) {
+        constraints.audio = constraintsToFF37(constraints.audio);
+      }
+      if (constraints.video) {
+        constraints.video = constraintsToFF37(constraints.video);
+      }
+      webrtcUtils.log('ff37: ' + JSON.stringify(constraints));
+    }
+    return navigator.mozGetUserMedia(constraints, onSuccess, onError);
+  };
 
   navigator.getUserMedia = getUserMedia;
 
   // Shim for mediaDevices on older versions.
   if (!navigator.mediaDevices) {
-    navigator.mediaDevices = {getUserMedia: requestUserMedia};
+    navigator.mediaDevices = {getUserMedia: requestUserMedia,
+      addEventListener: function() { },
+      removeEventListener: function() { }
+    };
   }
   navigator.mediaDevices.enumerateDevices =
       navigator.mediaDevices.enumerateDevices || function() {
     return new Promise(function(resolve) {
       var infos = [
-        {kind: 'audioinput', deviceId: 'default', label:'', groupId:''},
-        {kind: 'videoinput', deviceId: 'default', label:'', groupId:''}
+        {kind: 'audioinput', deviceId: 'default', label: '', groupId: ''},
+        {kind: 'videoinput', deviceId: 'default', label: '', groupId: ''}
       ];
       resolve(infos);
     });
   };
+
   if (webrtcDetectedVersion < 41) {
     // Work around http://bugzil.la/1169665
     var orgEnumerateDevices =
@@ -156,17 +189,15 @@ if (navigator.mozGetUserMedia) {
   }
   // Attach a media stream to an element.
   attachMediaStream = function(element, stream) {
-    console.log('Attaching media stream');
     element.mozSrcObject = stream;
   };
 
   reattachMediaStream = function(to, from) {
-    console.log('Reattaching media stream');
     to.mozSrcObject = from.mozSrcObject;
   };
 
 } else if (navigator.webkitGetUserMedia) {
-  console.log('This appears to be Chrome');
+  webrtcUtils.log('This appears to be Chrome');
 
   webrtcDetectedBrowser = 'chrome';
 
@@ -179,8 +210,59 @@ if (navigator.mozGetUserMedia) {
 
   // The RTCPeerConnection object.
   window.RTCPeerConnection = function(pcConfig, pcConstraints) {
-    return new webkitRTCPeerConnection(pcConfig, pcConstraints);
+    // Translate iceTransportPolicy to iceTransports,
+    // see https://code.google.com/p/webrtc/issues/detail?id=4869
+    if (pcConfig && pcConfig.iceTransportPolicy) {
+      pcConfig.iceTransports = pcConfig.iceTransportPolicy;
+    }
+
+    var pc = new webkitRTCPeerConnection(pcConfig, pcConstraints); // jscs:ignore requireCapitalizedConstructors
+    var origGetStats = pc.getStats.bind(pc);
+    pc.getStats = function(selector, successCallback, errorCallback) { // jshint ignore: line
+      var self = this;
+      var args = arguments;
+
+      // If selector is a function then we are in the old style stats so just
+      // pass back the original getStats format to avoid breaking old users.
+      if (arguments.length > 0 && typeof selector === 'function') {
+        return origGetStats(selector, successCallback);
+      }
+
+      var fixChromeStats = function(response) {
+        var standardReport = {};
+        var reports = response.result();
+        reports.forEach(function(report) {
+          var standardStats = {
+            id: report.id,
+            timestamp: report.timestamp,
+            type: report.type
+          };
+          report.names().forEach(function(name) {
+            standardStats[name] = report.stat(name);
+          });
+          standardReport[standardStats.id] = standardStats;
+        });
+
+        return standardReport;
+      };
+
+      if (arguments.length >= 2) {
+        var successCallbackWrapper = function(response) {
+          args[1](fixChromeStats(response));
+        };
+
+        return origGetStats.apply(this, [successCallbackWrapper, arguments[0]]);
+      }
+
+      // promise-support
+      return new Promise(function(resolve, reject) {
+        origGetStats.apply(self, [resolve, reject]);
+      });
+    };
+
+    return pc;
   };
+
   // add promise support
   ['createOffer', 'createAnswer'].forEach(function(method) {
     var nativeMethod = webkitRTCPeerConnection.prototype[method];
@@ -224,81 +306,68 @@ if (navigator.mozGetUserMedia) {
   });
 
   // getUserMedia constraints shim.
-  getUserMedia = function(c, onSuccess, onError) {
-    var constraintsToChrome = function(c) {
-      if (typeof c !== 'object' || c.mandatory || c.optional) {
-        return c;
+  var constraintsToChrome = function(c) {
+    if (typeof c !== 'object' || c.mandatory || c.optional) {
+      return c;
+    }
+    var cc = {};
+    Object.keys(c).forEach(function(key) {
+      if (key === 'require' || key === 'advanced' || key === 'mediaSource') {
+        return;
       }
-      var cc = {};
-      Object.keys(c).forEach(function(key) {
-        if (key === 'require' || key === 'advanced') {
-          return;
+      var r = (typeof c[key] === 'object') ? c[key] : {ideal: c[key]};
+      if (r.exact !== undefined && typeof r.exact === 'number') {
+        r.min = r.max = r.exact;
+      }
+      var oldname = function(prefix, name) {
+        if (prefix) {
+          return prefix + name.charAt(0).toUpperCase() + name.slice(1);
         }
-        var r = (typeof c[key] === 'object') ? c[key] : {ideal: c[key]};
-        if (r.exact !== undefined && typeof r.exact === 'number') {
-          r.min = r.max = r.exact;
-        }
-        var oldname = function(prefix, name) {
-          if (prefix) {
-            return prefix + name.charAt(0).toUpperCase() + name.slice(1);
-          }
-          return (name === 'deviceId') ? 'sourceId' : name;
-        };
-        if (r.ideal !== undefined) {
-          cc.optional = cc.optional || [];
-          var oc = {};
-          if (typeof r.ideal === 'number') {
-            oc[oldname('min', key)] = r.ideal;
-            cc.optional.push(oc);
-            oc = {};
-            oc[oldname('max', key)] = r.ideal;
-            cc.optional.push(oc);
-          } else {
-            oc[oldname('', key)] = r.ideal;
-            cc.optional.push(oc);
-          }
-        }
-        if (r.exact !== undefined && typeof r.exact !== 'number') {
-          cc.mandatory = cc.mandatory || {};
-          cc.mandatory[oldname('', key)] = r.exact;
+        return (name === 'deviceId') ? 'sourceId' : name;
+      };
+      if (r.ideal !== undefined) {
+        cc.optional = cc.optional || [];
+        var oc = {};
+        if (typeof r.ideal === 'number') {
+          oc[oldname('min', key)] = r.ideal;
+          cc.optional.push(oc);
+          oc = {};
+          oc[oldname('max', key)] = r.ideal;
+          cc.optional.push(oc);
         } else {
-          ['min', 'max'].forEach(function(mix) {
-            if (r[mix] !== undefined) {
-              cc.mandatory = cc.mandatory || {};
-              cc.mandatory[oldname(mix, key)] = r[mix];
-            }
-          });
+          oc[oldname('', key)] = r.ideal;
+          cc.optional.push(oc);
         }
-      });
-      if (c.advanced) {
-        cc.optional = (cc.optional || []).concat(c.advanced);
       }
-      return cc;
-    };
-    console.log('spec:   ' + JSON.stringify(c)); // whitespace for alignment
-    c.audio = constraintsToChrome(c.audio);
-    c.video = constraintsToChrome(c.video);
-    console.log('chrome: ' + JSON.stringify(c));
-    return navigator.webkitGetUserMedia(c, onSuccess, onError);
+      if (r.exact !== undefined && typeof r.exact !== 'number') {
+        cc.mandatory = cc.mandatory || {};
+        cc.mandatory[oldname('', key)] = r.exact;
+      } else {
+        ['min', 'max'].forEach(function(mix) {
+          if (r[mix] !== undefined) {
+            cc.mandatory = cc.mandatory || {};
+            cc.mandatory[oldname(mix, key)] = r[mix];
+          }
+        });
+      }
+    });
+    if (c.advanced) {
+      cc.optional = (cc.optional || []).concat(c.advanced);
+    }
+    return cc;
+  };
+
+  getUserMedia = function(constraints, onSuccess, onError) {
+    if (constraints.audio) {
+      constraints.audio = constraintsToChrome(constraints.audio);
+    }
+    if (constraints.video) {
+      constraints.video = constraintsToChrome(constraints.video);
+    }
+    webrtcUtils.log('chrome: ' + JSON.stringify(constraints));
+    return navigator.webkitGetUserMedia(constraints, onSuccess, onError);
   };
   navigator.getUserMedia = getUserMedia;
-
-  // Attach a media stream to an element.
-  attachMediaStream = function(element, stream) {
-    if (typeof element.srcObject !== 'undefined') {
-      element.srcObject = stream;
-    } else if (typeof element.mozSrcObject !== 'undefined') {
-      element.mozSrcObject = stream;
-    } else if (typeof element.src !== 'undefined') {
-      element.src = URL.createObjectURL(stream);
-    } else {
-      console.log('Error attaching stream to element.');
-    }
-  };
-
-  reattachMediaStream = function(to, from) {
-    to.src = from.src;
-  };
 
   if (!navigator.mediaDevices) {
     navigator.mediaDevices = {getUserMedia: requestUserMedia,
@@ -316,8 +385,77 @@ if (navigator.mozGetUserMedia) {
       });
     }};
   }
+
+  // A shim for getUserMedia method on the mediaDevices object.
+  // TODO(KaptenJansson) remove once implemented in Chrome stable.
+  if (!navigator.mediaDevices.getUserMedia) {
+    navigator.mediaDevices.getUserMedia = function(constraints) {
+      return requestUserMedia(constraints);
+    };
+  } else {
+    // Even though Chrome 45 has navigator.mediaDevices and a getUserMedia
+    // function which returns a Promise, it does not accept spec-style
+    // constraints.
+    var origGetUserMedia = navigator.mediaDevices.getUserMedia.
+        bind(navigator.mediaDevices);
+    navigator.mediaDevices.getUserMedia = function(c) {
+      webrtcUtils.log('spec:   ' + JSON.stringify(c)); // whitespace for alignment
+      c.audio = constraintsToChrome(c.audio);
+      c.video = constraintsToChrome(c.video);
+      webrtcUtils.log('chrome: ' + JSON.stringify(c));
+      return origGetUserMedia(c);
+    };
+  }
+
+  // Dummy devicechange event methods.
+  // TODO(KaptenJansson) remove once implemented in Chrome stable.
+  if (typeof navigator.mediaDevices.addEventListener === 'undefined') {
+    navigator.mediaDevices.addEventListener = function() {
+      webrtcUtils.log('Dummy mediaDevices.addEventListener called.');
+    };
+  }
+  if (typeof navigator.mediaDevices.removeEventListener === 'undefined') {
+    navigator.mediaDevices.removeEventListener = function() {
+      webrtcUtils.log('Dummy mediaDevices.removeEventListener called.');
+    };
+  }
+
+  // Attach a media stream to an element.
+  attachMediaStream = function(element, stream) {
+    if (typeof element.srcObject !== 'undefined') {
+      element.srcObject = stream;
+    } else if (typeof element.src !== 'undefined') {
+      element.src = URL.createObjectURL(stream);
+    } else {
+      webrtcUtils.log('Error attaching stream to element.');
+    }
+  };
+
+  reattachMediaStream = function(to, from) {
+    to.src = from.src;
+  };
+
+} else if (navigator.mediaDevices && navigator.userAgent.match(
+    /Edge\/(\d+).(\d+)$/)) {
+  webrtcUtils.log('This appears to be Edge');
+  webrtcDetectedBrowser = 'edge';
+
+  webrtcDetectedVersion =
+    parseInt(navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)[2], 10);
+
+  // the minimum version still supported by adapter.
+  webrtcMinimumVersion = 12;
+
+  getUserMedia = navigator.getUserMedia;
+
+  attachMediaStream = function(element, stream) {
+    element.srcObject = stream;
+  };
+  reattachMediaStream = function(to, from) {
+    to.srcObject = from.srcObject;
+  };
 } else {
-  console.log('Browser does not appear to be WebRTC-capable');
+  webrtcUtils.log('Browser does not appear to be WebRTC-capable');
 }
 
 // Returns the result of getUserMedia as a Promise.
@@ -327,7 +465,18 @@ function requestUserMedia(constraints) {
   });
 }
 
+var webrtcTesting = {};
+Object.defineProperty(webrtcTesting, 'version', {
+  set: function(version) {
+    webrtcDetectedVersion = version;
+  }
+});
+
 if (typeof module !== 'undefined') {
+  var RTCPeerConnection;
+  if (typeof window !== 'undefined') {
+    RTCPeerConnection = window.RTCPeerConnection;
+  }
   module.exports = {
     RTCPeerConnection: RTCPeerConnection,
     getUserMedia: getUserMedia,
@@ -335,8 +484,25 @@ if (typeof module !== 'undefined') {
     reattachMediaStream: reattachMediaStream,
     webrtcDetectedBrowser: webrtcDetectedBrowser,
     webrtcDetectedVersion: webrtcDetectedVersion,
-    webrtcMinimumVersion: webrtcMinimumVersion
+    webrtcMinimumVersion: webrtcMinimumVersion,
+    webrtcTesting: webrtcTesting
     //requestUserMedia: not exposed on purpose.
     //trace: not exposed on purpose.
   };
+} else if ((typeof require === 'function') && (typeof define === 'function')) {
+  // Expose objects and functions when RequireJS is doing the loading.
+  define([], function() {
+    return {
+      RTCPeerConnection: window.RTCPeerConnection,
+      getUserMedia: getUserMedia,
+      attachMediaStream: attachMediaStream,
+      reattachMediaStream: reattachMediaStream,
+      webrtcDetectedBrowser: webrtcDetectedBrowser,
+      webrtcDetectedVersion: webrtcDetectedVersion,
+      webrtcMinimumVersion: webrtcMinimumVersion,
+      webrtcTesting: webrtcTesting
+      //requestUserMedia: not exposed on purpose.
+      //trace: not exposed on purpose.
+    };
+  });
 }

--- a/src/web_app/js/analytics.js
+++ b/src/web_app/js/analytics.js
@@ -16,10 +16,12 @@
  * @constructor
  */
 var Analytics = function(roomServer) {
-  /* @private {string} Room server URL. */
+  /* @private {String} Room server URL. */
   this.analyticsPath_ = roomServer + '/a/';
 };
 
+// Disable check here due to jscs not recognizing the types below.
+/* jscs: disable */
 /**
  * Defines a type for our event objects.
  * @typedef {
@@ -27,17 +29,18 @@ var Analytics = function(roomServer) {
  *   enums.RequestField.EventField.ROOM_ID: ?string,
  *   enums.RequestField.EventField.FLOWN_ID: ?number,
  *   enums.RequestField.EventField.EVENT_TIME_MS: number
- * }
+ * } 
  * @private
  */
+/* jscs: enable */
 Analytics.EventObject_ = {};
 
 /**
  * Report an event.
  *
  * @param {enums.EventType} eventType The event string to record.
- * @param {string=} roomId The current room ID.
- * @param {number=} flowId The current room ID.
+ * @param {String=} roomId The current room ID.
+ * @param {Number=} flowId The current room ID.
  */
 Analytics.prototype.reportEvent = function(eventType, roomId, flowId) {
   var eventObj = {};
@@ -55,6 +58,7 @@ Analytics.prototype.reportEvent = function(eventType, roomId, flowId) {
 
 /**
  * Send an event object to the server.
+ *
  * @param {Analytics.EventObject_} eventObj Event object to send.
  * @private
  */

--- a/src/web_app/js/analytics.js
+++ b/src/web_app/js/analytics.js
@@ -29,7 +29,7 @@ var Analytics = function(roomServer) {
  *   enums.RequestField.EventField.ROOM_ID: ?string,
  *   enums.RequestField.EventField.FLOWN_ID: ?number,
  *   enums.RequestField.EventField.EVENT_TIME_MS: number
- * } 
+ * }
  * @private
  */
 /* jscs: enable */

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -488,12 +488,12 @@ AppController.prototype.showIcons_ = function() {
 };
 
 AppController.prototype.loadUrlParams_ = function() {
+  /* jscs: disable */
   /* jshint ignore:start */
   // Suppressing jshint warns about using urlParams['KEY'] instead of
   // urlParams.KEY, since we'd like to use string literals to avoid the Closure
   // compiler renaming the properties.
-  var urlParams = queryStringToDictionary(window.location.search)
-
+  var urlParams = queryStringToDictionary(window.location.search);
   this.loadingParams_.audioSendBitrate = urlParams['asbr'];
   this.loadingParams_.audioSendCodec = urlParams['asc'];
   this.loadingParams_.audioRecvBitrate = urlParams['arbr'];
@@ -508,6 +508,7 @@ AppController.prototype.loadUrlParams_ = function() {
   this.loadingParams_.videoRecvBitrate = urlParams['vrbr'];
   this.loadingParams_.videoRecvCodec = urlParams['vrc'];
   /* jshint ignore:end */
+  /* jscs: enable */
 };
 
 AppController.IconSet_ = function(iconSelector) {

--- a/src/web_app/js/signalingchannel_test.js
+++ b/src/web_app/js/signalingchannel_test.js
@@ -40,7 +40,7 @@ SignalingChannelTest.prototype.testOpenSuccess = function() {
   var rejected = false;
   promise.then(function() {
     resolved = true;
-  }).catch (function() {
+  }).catch(function() {
     rejected = true;
   });
 
@@ -79,7 +79,7 @@ SignalingChannelTest.prototype.testOpenFailure = function() {
   var rejected = false;
   promise.then(function() {
     resolved = true;
-  }).catch (function() {
+  }).catch(function() {
     rejected = true;
   });
 


### PR DESCRIPTION
* Fixed jscs errors due to a new version of the grunt-contrib-jscs plugin
* Import adapter.js 0.1.9
* Fix jshint errors due to new stuff in adapter.js
* Add webrtc-adapter-test as a npm dependency
* Add post-install script that copies adapter.js to src/web_app/js/ (note that this only done with `npm install` so you have to do `npm install` and `npm update` to get the latest adapter copied over to the correct location after a new version of adapter has been fetched).