### PR TITLE
Attempt to fix manifest parsing error for icon density value #187

### DIFF
--- a/src/web_app/html/manifest.json
+++ b/src/web_app/html/manifest.json
@@ -6,7 +6,7 @@
       "src": "/images/webrtc-icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "density": "4.0"
+      "density": 4.0
     }
   ],
   "start_url": "/",


### PR DESCRIPTION
As per #187.

Changed density value from string to float.