### PR TITLE
Remove density setting for icon in manifest.json

### DIFF
--- a/src/web_app/html/manifest.json
+++ b/src/web_app/html/manifest.json
@@ -5,8 +5,7 @@
     {
       "src": "/images/webrtc-icon-192x192.png",
       "sizes": "192x192",
-      "type": "image/png",
-      "density": 4.0
+      "type": "image/png"
     }
   ],
   "start_url": "/",


### PR DESCRIPTION
On advice from Paul Kinlan: icons are chosen depending on resolution. Including a density value may cause an icon not to be chosen when it's actually the best/only option.