### PR TITLE
Use mediaStreamTrack.stop method

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -118,7 +118,7 @@ Call.prototype.hangup = function(async) {
   }
 
   if (this.localStream_) {
-    this.localStream_.stop();
+    this.localStream_.getTracks().forEach(function(track) { track.stop(); });
     this.localStream_ = null;
   }
 


### PR DESCRIPTION
This fails due to phantomjs uses webkit Safari 534.34 which is from 2011.

Will make a separate PR for updating/replacing phantomjs.