### PR TITLE
Close tracks rather than the media stream.

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -118,9 +118,14 @@ Call.prototype.hangup = function(async) {
   }
 
   if (this.localStream_) {
-    this.localStream_.getTracks().forEach(function(track) {
-      track.stop();
-    });
+    if (typeof this.localStream_.stop === "function") {
+      // Support legacy browsers, like phantomJs we use to run tests.
+      this.localStream_.stop();
+    } else {
+      this.localStream_.getTracks().forEach(function(track) {
+        track.stop();
+      });
+    }
     this.localStream_ = null;
   }
 

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -118,7 +118,9 @@ Call.prototype.hangup = function(async) {
   }
 
   if (this.localStream_) {
-    this.localStream_.stop();
+    this.localStream_.getTracks().forEach(function(track) {
+      track.stop();
+    });
     this.localStream_ = null;
   }
 

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -118,7 +118,7 @@ Call.prototype.hangup = function(async) {
   }
 
   if (this.localStream_) {
-    if (typeof this.localStream_.stop === "function") {
+    if (typeof this.localStream_.stop === 'function') {
       // Support legacy browsers, like phantomJs we use to run tests.
       this.localStream_.stop();
     } else {


### PR DESCRIPTION
mediaStream.stop() is deprecated and has been removed; this makes us close the tracks instead.

Context: https://code.google.com/p/chromium/issues/detail?id=535588.