### PR TITLE
Check if getTracks exists

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -118,7 +118,7 @@ Call.prototype.hangup = function(async) {
   }
 
   if (this.localStream_) {
-    if (typeof this.localStream_.stop === 'function') {
+    if (typeof this.localStream_.getTracks === 'undefined') {
       // Support legacy browsers, like phantomJs we use to run tests.
       this.localStream_.stop();
     } else {


### PR DESCRIPTION
This makes sure we do not use mediaStream.stop() if it exists on browsers that support getTracks as well.