### PR TITLE
Check for undefined codec

### DIFF
--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -226,7 +226,7 @@ function maybePreferVideoReceiveCodec(sdp, params) {
 // The format of |codec| is 'NAME/RATE', e.g. 'opus/48000'.
 function maybePreferCodec(sdp, type, dir, codec) {
   var str = type + ' ' + dir + ' codec';
-  if (codec === '') {
+  if (typeof codec === 'undefined' || codec === '') {
     trace('No preference on ' + str + '.');
     return sdp;
   }

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -226,7 +226,7 @@ function maybePreferVideoReceiveCodec(sdp, params) {
 // The format of |codec| is 'NAME/RATE', e.g. 'opus/48000'.
 function maybePreferCodec(sdp, type, dir, codec) {
   var str = type + ' ' + dir + ' codec';
-  if (typeof codec === 'undefined' || codec === '') {
+  if (!codec) {
     trace('No preference on ' + str + '.');
     return sdp;
   }


### PR DESCRIPTION
If no codec parameters are specified, codec is undefined not an empty string.

I left the condition for an empty string due to I suppose we should handle the case where the vsc & vrc parameters are provided without any codec specified.