### PR TITLE
Add warningMessages function for non fatal warnings, fix encode issue

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -217,7 +217,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   if hd and video:
     message = 'The "hd" parameter has overridden video=' + video
     logging.warning(message)
-    # HTML template is UTF-8 while python defaults to unicode.
+    # HTML template is UTF-8, make sure the string is UTF-8 as well.
     warning_messages.append(message.encode('utf-8'))
   if hd == 'true':
     video = 'mandatory:minWidth=1280,mandatory:minHeight=720'
@@ -228,7 +228,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     message = ('The "minre" and "maxre" parameters are no longer ' +
         'supported. Use "video" instead.')
     logging.warning(message)
-    # HTML template is UTF-8 while python defaults to unicode.
+    # HTML template is UTF-8, make sure the string is UTF-8 as well.
     warning_messages.append(message.encode('utf-8'))
 
   # Options for controlling various networking features.

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -157,6 +157,7 @@ def get_version_info():
 # TODO(tkchin): move query parameter parsing to JS code.
 def get_room_parameters(request, room_id, client_id, is_initiator):
   error_messages = []
+  warning_messages = []
   # Get the base url without arguments.
   base_url = request.path_url
   user_agent = request.headers['User-Agent']
@@ -215,18 +216,20 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   hd = request.get('hd').lower()
   if hd and video:
     message = 'The "hd" parameter has overridden video=' + video
-    logging.error(message)
-    error_messages.append(message)
+    logging.warning(message)
+    # HTML template is UTF-8 while python defaults to unicode.
+    warning_messages.append(message.encode('utf-8'))
   if hd == 'true':
     video = 'mandatory:minWidth=1280,mandatory:minHeight=720'
   elif not hd and not video and get_hd_default(user_agent) == 'true':
     video = 'optional:minWidth=1280,optional:minHeight=720'
 
   if request.get('minre') or request.get('maxre'):
-    message = ('The "minre" and "maxre" parameters are no longer supported. '
-              'Use "video" instead.')
-    logging.error(message)
-    error_messages.append(message)
+    message = ('The "minre" and "maxre" parameters are no longer ' +
+        'supported. Use "video" instead.')
+    logging.warning(message)
+    # HTML template is UTF-8 while python defaults to unicode.
+    warning_messages.append(message.encode('utf-8'))
 
   # Options for controlling various networking features.
   dtls = request.get('dtls')
@@ -263,6 +266,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
 
   params = {
     'error_messages': error_messages,
+    'warning_messages': warning_messages,
     'is_loopback' : json.dumps(debug == 'loopback'),
     'pc_config': json.dumps(pc_config),
     'pc_constraints': json.dumps(pc_constraints),

--- a/src/app_engine/apprtc_test.py
+++ b/src/app_engine/apprtc_test.py
@@ -84,6 +84,7 @@ class AppRtcPageHandlerTest(unittest.TestCase):
     self.assertEqual(json.dumps(is_initiator), params['is_initiator'])
     self.assertEqual(room_id, params['room_id'])
     self.assertEqual([], params['error_messages'])
+    self.assertEqual([], params['warning_messages'])
     return caller_id
 
   def testConnectingWithoutRoomIdServesIndex(self):

--- a/src/web_app/html/index_template.html
+++ b/src/web_app/html/index_template.html
@@ -126,6 +126,7 @@
     var loadingParams = {
       errorMessages: {{ error_messages }},
       isLoopback: {{ is_loopback }},
+      warningMessages: {{ warning_messages }},
 {% if room_id %}
       roomId: '{{ room_id }}',
       roomLink: '{{ room_link }}',

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -149,11 +149,16 @@ AppController.prototype.createCall_ = function() {
                               this.loadingParams_.versionInfo);
 
   var roomErrors = this.loadingParams_.errorMessages;
+  var roomWarnings = this.loadingParams_.warningMessages;
   if (roomErrors && roomErrors.length > 0) {
     for (var i = 0; i < roomErrors.length; ++i) {
       this.infoBox_.pushErrorMessage(roomErrors[i]);
     }
     return;
+  } else if (roomWarnings && roomWarnings.length > 0) {
+    for (var j = 0; j < roomWarnings.length; ++j) {
+      this.infoBox_.pushWarningMessage(roomWarnings[j]);
+    }
   }
 
   // TODO(jiayl): replace callbacks with events.

--- a/src/web_app/js/appwindow.js
+++ b/src/web_app/js/appwindow.js
@@ -17,6 +17,7 @@
 var roomServer = 'https://apprtc.appspot.com';
 var loadingParams = {
   errorMessages: [],
+  warningMessages: [],
   suggestedRoomId: randomString(9),
   roomServer: roomServer,
   connect: false,

--- a/src/web_app/js/infobox.js
+++ b/src/web_app/js/infobox.js
@@ -21,6 +21,7 @@ var InfoBox = function(infoDiv, remoteVideo, call, versionInfo) {
   this.versionInfo_ = versionInfo;
 
   this.errorMessages_ = [];
+  this.warningMessages_ = [];
   // Time when the call was intiated and accepted.
   this.startTime_ = null;
   this.connectTime_ = null;
@@ -49,6 +50,12 @@ InfoBox.prototype.recordIceCandidateTypes = function(location, candidate) {
 
 InfoBox.prototype.pushErrorMessage = function(msg) {
   this.errorMessages_.push(msg);
+  this.updateInfoDiv();
+  this.showInfoDiv();
+};
+
+InfoBox.prototype.pushWarningMessage = function(msg) {
+  this.warningMessages_.push(msg);
   this.updateInfoDiv();
   this.showInfoDiv();
 };
@@ -136,10 +143,19 @@ InfoBox.prototype.updateInfoDiv = function() {
     contents += this.buildStatsSection_();
   }
 
-  if (this.errorMessages_.length) {
-    this.infoDiv_.classList.add('warning');
-    for (var i = 0; i !== this.errorMessages_.length; ++i) {
-      contents += this.errorMessages_[i] + '\n';
+
+  if (this.errorMessages_.length > 0 || this.warningMessages_.length > 0) {
+    contents += this.buildLine_('\nMessages');
+    if (this.errorMessages_.length) {
+      this.infoDiv_.classList.add('warning');
+      for (var i = 0; i !== this.errorMessages_.length; ++i) {
+        contents += this.errorMessages_[i] + '\n';
+      }
+    } else {
+      this.infoDiv_.classList.add('active');
+      for (var j = 0; j !== this.warningMessages_.length; ++j) {
+        contents += this.warningMessages_[j] + '\n';
+      }
     }
   } else {
     this.infoDiv_.classList.remove('warning');

--- a/src/web_app/js/infobox.js
+++ b/src/web_app/js/infobox.js
@@ -143,7 +143,6 @@ InfoBox.prototype.updateInfoDiv = function() {
     contents += this.buildStatsSection_();
   }
 
-
   if (this.errorMessages_.length > 0 || this.warningMessages_.length > 0) {
     contents += this.buildLine_('\nMessages');
     if (this.errorMessages_.length) {


### PR DESCRIPTION
Fixes #211 

* Add warning_messages reporting functionality, both the HD + video and minre params do not have to be fatal hence making a separate message functionality for those type of messages.
* The issue in #211 is that the [HTML template](https://github.com/webrtc/apprtc/blob/master/src/web_app/html/index_template.html) is UTF-8 while python uses unicode by default. This results in python appending a `u` for unicode before the string in the array `[u'string']` which does not make Javascript happy ;), it does not affect all messages though, possible due to including the URL parameter in the string.

A more permanent solution would to create a wrapper that converts all incoming strings saving the use of string.encode('utf-8') on all messages to be pushed to a template. But since there were only two warning_messages to be printed and no error_messages I do not want to spend the time on it, also we might use a different templating framework in the future.

 