### PR TITLE
Update collider_test.go websocket dependency.

### DIFF
--- a/src/collider/collider/collider_test.go
+++ b/src/collider/collider/collider_test.go
@@ -6,7 +6,7 @@
 package collider
 
 import (
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"encoding/json"
 	"flag"
 	"fmt"


### PR DESCRIPTION
The websocket hosted on code.google.com no longer exists,
which breaks our Chromium bots in
https://build.chromium.org/p/chromium.webrtc/waterfall

BUG=http://crbug.com/567598