### PR TITLE
remove createAnswer constraints/options

### DIFF
--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -170,15 +170,8 @@ PeerConnectionClient.prototype.getPeerConnectionStats = function(callback) {
 
 PeerConnectionClient.prototype.doAnswer_ = function() {
   trace('Sending answer to peer.');
-  var p;
-  if (webrtcDetectedBrowser === 'firefox') {
-    // Firefox does not support this yet, see
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1098015
-    p = this.pc_.createAnswer();
-  } else {
-    p = this.pc_.createAnswer(PeerConnectionClient.DEFAULT_SDP_OFFER_OPTIONS_);
-  }
-  p.then(this.setLocalSdpAndNotify_.bind(this))
+  this.pc_.createAnswer()
+  .then(this.setLocalSdpAndNotify_.bind(this))
   .catch(this.onError_.bind(this, 'createAnswer'));
 };
 


### PR DESCRIPTION
When I updated the constraints to the new offer format I forgot to remove the offerOptions parameter for createAnswer as it no longer accepts any parameters.

http://www.w3.org/TR/webrtc/#widl-RTCPeerConnection-createAnswer-Promise-RTCSessionDescription