### PR TITLE
Improve URL param parsing functions

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -13,6 +13,7 @@ import logging
 import os
 import random
 import threading
+from urllib import quote
 
 import jinja2
 import webapp2
@@ -112,11 +113,11 @@ def append_url_arguments(request, link):
   arguments = request.arguments()
   if len(arguments) == 0:
     return link
-  link += ('?' + cgi.escape(arguments[0], True) + '=' +
-           cgi.escape(request.get(arguments[0]), True))
+  link += ('?' + cgi.escape(quote(arguments[0]), True) + '=' +
+           cgi.escape(quote(request.get(arguments[0])), True))
   for argument in arguments[1:]:
-    link += ('&' + cgi.escape(argument, True) + '=' +
-             cgi.escape(request.get(argument), True))
+    link += ('&' + cgi.escape(quote(argument), True) + '=' +
+             cgi.escape(quote(request.get(argument)), True))
   return link
 
 def get_wss_parameters(request):
@@ -219,7 +220,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   # doesn't actually support HD modes.
   hd = request.get('hd').lower()
   if hd and video:
-    message = 'The "hd" parameter has overridden video=' + video
+    message = 'The "hd" parameter has overridden video=' + quote(video)
     logging.warning(message)
     # HTML template is UTF-8, make sure the string is UTF-8 as well.
     warning_messages.append(message.encode('utf-8'))
@@ -255,6 +256,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   if len(turn_base_url) > 0:
     turn_url = constants.TURN_URL_TEMPLATE % \
         (turn_base_url, username, constants.CEOD_KEY)
+    print turn_url
   else:
     turn_url = ''
 
@@ -276,8 +278,8 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     'pc_constraints': json.dumps(pc_constraints),
     'offer_options': json.dumps(offer_options),
     'media_constraints': json.dumps(media_constraints),
-    'turn_url': turn_url,
-    'turn_transports': turn_transports,
+    'turn_url': quote(turn_url),
+    'turn_transports': quote(turn_transports),
     'include_loopback_js' : include_loopback_js,
     'wss_url': wss_url,
     'wss_post_url': wss_post_url,

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -256,7 +256,6 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   if len(turn_base_url) > 0:
     turn_url = constants.TURN_URL_TEMPLATE % \
         (turn_base_url, username, constants.CEOD_KEY)
-    print turn_url
   else:
     turn_url = ''
 

--- a/src/web_app/html/index_template.html
+++ b/src/web_app/html/index_template.html
@@ -132,7 +132,7 @@
       roomLink: '{{ room_link }}',
 {% endif %}
 
-      mediaConstraints: {{ media_constraints | safe }},
+      mediaConstraints: {{ media_constraints }},
       offerOptions: {{ offer_options | safe }},
       peerConnectionConfig: {{ pc_config | safe }},
       peerConnectionConstraints: {{ pc_constraints | safe }},
@@ -141,7 +141,7 @@
       wssUrl: '{{ wss_url }}',
       wssPostUrl: '{{ wss_post_url }}',
       bypassJoinConfirmation: {{ bypass_join_confirmation }},
-      versionInfo: {{ version_info }}
+      versionInfo: {{ version_info | safe }}
     };
 
     var appController;

--- a/src/web_app/js/infobox.js
+++ b/src/web_app/js/infobox.js
@@ -148,12 +148,12 @@ InfoBox.prototype.updateInfoDiv = function() {
     if (this.errorMessages_.length) {
       this.infoDiv_.classList.add('warning');
       for (var i = 0; i !== this.errorMessages_.length; ++i) {
-        contents += this.errorMessages_[i] + '\n';
+        contents += decodeURIComponent(this.errorMessages_[i]) + '\n';
       }
     } else {
       this.infoDiv_.classList.add('active');
       for (var j = 0; j !== this.warningMessages_.length; ++j) {
-        contents += this.warningMessages_[j] + '\n';
+        contents += decodeURIComponent(this.warningMessages_[j]) + '\n';
       }
     }
   } else {

--- a/src/web_app/js/util.js
+++ b/src/web_app/js/util.js
@@ -65,8 +65,6 @@ function sendUrlRequest(method, url, async, body) {
         reportResults();
       };
     }
-    console.log(method, url, async);
-    console.log(encodeURIComponent(url));
     xhr.open(method, decodeURIComponent(url), async);
     xhr.send(body);
 

--- a/src/web_app/js/util.js
+++ b/src/web_app/js/util.js
@@ -65,7 +65,9 @@ function sendUrlRequest(method, url, async, body) {
         reportResults();
       };
     }
-    xhr.open(method, url, async);
+    console.log(method, url, async);
+    console.log(encodeURIComponent(url));
+    xhr.open(method, decodeURIComponent(url), async);
     xhr.send(body);
 
     if (!async) {


### PR DESCRIPTION
I used [quote](https://docs.python.org/2/library/urllib.html#urllib.quote) from Urllib to escape special characters and then decodeURIComponent() (in javascript) to convert back to a string that makes sense for URL's.