### PR TITLE
Correcting collider symlink instructions.

### DIFF
--- a/src/collider/README.md
+++ b/src/collider/README.md
@@ -12,9 +12,9 @@ A websocket-based signaling server in Go.
 
 3. Link the collider directories into `$GOPATH/src`
 
-        ln -s apprtc/src/collider/collider $GOPATH/src/
-        ln -s apprtc/src/collider/collidermain $GOPATH/src/
-        ln -s apprtc/src/collider/collidertest $GOPATH/src/
+        ln -rs apprtc/src/collider/collider $GOPATH/src/
+        ln -rs apprtc/src/collider/collidermain $GOPATH/src/
+        ln -rs apprtc/src/collider/collidertest $GOPATH/src/
 
 4. Install dependencies
 


### PR DESCRIPTION
I found after quite a bit of work that the collider build instructions only work if one's directories are arranged in a certain way. This correction should work for everyone.