### PR TITLE
Make sure certificate is generated before a peerconnection has been created

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -426,22 +426,15 @@ Call.prototype.maybeCreatePcClientAsync_ = function() {
       var certParams = {name: 'ECDSA', namedCurve: 'P-256'};
       RTCPeerConnection.generateCertificate(certParams)
       .then(function(cert) {
-        trace('ECDSA Certificate generated successfully.');
+        trace('ECDSA certificate generated successfully.');
         this.params_.peerConnectionConfig.certificates = [cert];
         this.createPcClient_();
         resolve();
       }.bind(this))
       .catch(function(error) {
-        if (this.params_.peerConnectionConfig.certificates) {
-          reject(error);
-        } else {
-          // This is not a critical error hence why it should continue
-          // setting up the call.
-          trace('Could not generate a certificate: ' + error);
-          this.createPcClient_();
-          resolve();
-        }
-      }.bind(this));
+        trace('ECDSA certificate generation failed.');
+        reject(error);
+      });
     } else {
       this.createPcClient_();
       resolve();

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -415,11 +415,13 @@ Call.prototype.onUserMediaError_ = function(error) {
   alert(errorMessage);
 };
 
-Call.prototype.maybeCreatePcClient_ = function() {
-  if (this.pcClient_) {
-    return;
-  }
+Call.prototype.maybeCreatePcClientAsync_ = function() {
   return new Promise(function(resolve, reject) {
+    if (this.pcClient_) {
+      resolve();
+      return;
+    }
+
     if (typeof RTCPeerConnection.generateCertificate === 'function') {
       var certParams = {name: 'ECDSA', namedCurve: 'P-256'};
       RTCPeerConnection.generateCertificate(certParams)
@@ -468,7 +470,7 @@ Call.prototype.startSignaling_ = function() {
 
   this.startTime = window.performance.now();
 
-  this.maybeCreatePcClient_()
+  this.maybeCreatePcClientAsync_()
   .then(function() {
     if (this.localStream_) {
       trace('Adding local stream.');
@@ -517,8 +519,8 @@ Call.prototype.joinRoom_ = function() {
 };
 
 Call.prototype.onRecvSignalingChannelMessage_ = function(msg) {
-  this.maybeCreatePcClient_();
-  this.pcClient_.receiveSignalingMessage(msg);
+  this.maybeCreatePcClientAsync_()
+  .then(this.pcClient_.receiveSignalingMessage(msg));
 };
 
 Call.prototype.sendSignalingMessage_ = function(message) {

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -29,17 +29,6 @@ var PeerConnectionClient = function(params, startTime) {
     '  constraints: \'' + JSON.stringify(params.peerConnectionConstraints) +
     '\'.');
 
-  if (typeof RTCPeerConnection.generateCertificate === 'function') {
-    RTCPeerConnection.generateCertificate({name: 'ECDSA', namedCurve: 'P-256'})
-    .then(function(cert) {
-      trace('Certificate generated successfully.');
-      params.peerConnectionConfig.certificates = [cert];
-    })
-    .catch(function(error) {
-      trace('Could not generate a certificate: ' + error);
-    });
-  }
-
   // Create an RTCPeerConnection via the polyfill (adapter.js).
   this.pc_ = new RTCPeerConnection(
       params.peerConnectionConfig, params.peerConnectionConstraints);


### PR DESCRIPTION
I had to move the cert creation out of the peerconnectionclient into call.js which is fine IMHO since it's actually creating/adding parameters for the peerConnection which call.js is already doing.

Fixes #258