### PR TITLE
Typo bug fix

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -257,7 +257,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     ice_server_url = constants.ICE_SERVER_URL_TEMPLATE % \
         (ice_server_base_url, constants.ICE_SERVER_API_KEY)
   else:
-    ice_server = ''
+    ice_server_url = ''
 
   turn_url = constants.TURN_URL_TEMPLATE % \
       (constants.TURN_BASE_URL, username, constants.CEOD_KEY)


### PR DESCRIPTION
Fix the crash when Constants#ICE_SERVER_BASE_URL and the 'ts' param in
request are both empty.

ice_server should be ice_server_base_url, I think it's a typo.