### PR TITLE
Update getStats format

### DIFF
--- a/src/web_app/js/infobox.js
+++ b/src/web_app/js/infobox.js
@@ -83,7 +83,7 @@ InfoBox.prototype.toggleInfoDiv = function() {
 InfoBox.prototype.refreshStats_ = function() {
   this.call_.getPeerConnectionStats(function(response) {
     this.prevStats_ = this.stats_;
-    this.stats_ = response.result();
+    this.stats_ = response;
     this.updateInfoDiv();
   }.bind(this));
 };
@@ -116,20 +116,20 @@ InfoBox.prototype.updateInfoDiv = function() {
     var localAddrType;
     var remoteAddrType;
     if (activeCandPair) {
-      localAddr = activeCandPair.stat('googLocalAddress');
-      remoteAddr = activeCandPair.stat('googRemoteAddress');
-      localAddrType = activeCandPair.stat('googLocalCandidateType');
-      remoteAddrType = activeCandPair.stat('googRemoteCandidateType');
+      localAddr = activeCandPair.googLocalAddress;
+      remoteAddr = activeCandPair.googRemoteAddress;
+      localAddrType = activeCandPair.googLocalCandidateType;
+      remoteAddrType = activeCandPair.googRemoteCandidateType;
     }
     if (localAddr && remoteAddr) {
-      var localCandId = activeCandPair.stat('localCandidateId');
+      var localCandId = activeCandPair.localCandidateId;
       var localCand;
       var localTypePref;
       if (localCandId) {
         localCand = getStatsReport(this.stats_, 'localcandidate', 'id',
             localCandId);
         if (localCand) {
-          localTypePref = localCand.stat('priority') >> 24;
+          localTypePref = localCand.priority >> 24;
         }
       }
       contents += this.buildLine_('LocalAddr', localAddr +
@@ -223,7 +223,7 @@ InfoBox.prototype.buildStatsSection_ = function() {
   var rxVideoBitrate;
   var rxVideoPacketRate;
   if (txAudio) {
-    txAudioCodec = txAudio.stat('googCodecName');
+    txAudioCodec = txAudio.googCodecName;
     txAudioBitrate = computeBitrate(txAudio, txPrevAudio, 'bytesSent');
     txAudioPacketRate = computeRate(txAudio, txPrevAudio, 'packetsSent');
     contents += this.buildLine_('Audio Tx', txAudioCodec + ', ' +
@@ -231,7 +231,7 @@ InfoBox.prototype.buildStatsSection_ = function() {
         InfoBox.formatPacketRate_(txAudioPacketRate));
   }
   if (rxAudio) {
-    rxAudioCodec = rxAudio.stat('googCodecName');
+    rxAudioCodec = rxAudio.googCodecName;
     rxAudioBitrate = computeBitrate(rxAudio, rxPrevAudio, 'bytesReceived');
     rxAudioPacketRate = computeRate(rxAudio, rxPrevAudio, 'packetsReceived');
     contents += this.buildLine_('Audio Rx', rxAudioCodec + ', ' +
@@ -239,9 +239,9 @@ InfoBox.prototype.buildStatsSection_ = function() {
         InfoBox.formatPacketRate_(rxAudioPacketRate));
   }
   if (txVideo) {
-    txVideoCodec = txVideo.stat('googCodecName');
-    txVideoHeight = txVideo.stat('googFrameHeightSent');
-    txVideoFps = txVideo.stat('googFrameRateSent');
+    txVideoCodec = txVideo.googCodecName;
+    txVideoHeight = txVideo.googFrameHeightSent;
+    txVideoFps = txVideo.googFrameRateSent;
     txVideoBitrate = computeBitrate(txVideo, txPrevVideo, 'bytesSent');
     txVideoPacketRate = computeRate(txVideo, txPrevVideo, 'packetsSent');
     contents += this.buildLine_('Video Tx',
@@ -251,10 +251,10 @@ InfoBox.prototype.buildStatsSection_ = function() {
         InfoBox.formatPacketRate_(txVideoPacketRate));
   }
   if (rxVideo) {
-    rxVideoCodec = 'TODO';  // rxVideo.stat('googCodecName');
+    rxVideoCodec = rxVideo.googCodecName;
     rxVideoHeight = this.remoteVideo_.videoHeight;
     // TODO(juberti): this should ideally be obtained from the video element.
-    rxVideoFps = rxVideo.stat('googFrameRateDecoded');
+    rxVideoFps = rxVideo.googFrameRateDecoded;
     rxVideoBitrate = computeBitrate(rxVideo, rxPrevVideo, 'bytesReceived');
     rxVideoPacketRate = computeRate(rxVideo, rxPrevVideo, 'packetsReceived');
     contents += this.buildLine_('Video Rx',

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -165,7 +165,8 @@ PeerConnectionClient.prototype.getPeerConnectionStats = function(callback) {
   if (!this.pc_) {
     return;
   }
-  this.pc_.getStats(callback);
+  this.pc_.getStats(null)
+  .then(callback);
 };
 
 PeerConnectionClient.prototype.doAnswer_ = function() {

--- a/src/web_app/js/stats.js
+++ b/src/web_app/js/stats.js
@@ -33,8 +33,8 @@ function extractStatAsInt(stats, statObj, statName) {
 // as a string, or null if not present.
 function extractStat(stats, statObj, statName) {
   var report = getStatsReport(stats, statObj, statName);
-  if (report && report.names().indexOf(statName) !== -1) {
-    return report.stat(statName);
+  if (report && report[statName] !== -1) {
+    return report[statName];
   }
   return null;
 }
@@ -44,14 +44,14 @@ function extractStat(stats, statObj, statName) {
 // undef if not present.
 function getStatsReport(stats, statObj, statName, statVal) {
   if (stats) {
-    for (var i = 0; i < stats.length; ++i) {
-      var report = stats[i];
+    for (var stat in stats) {
+      var report = stats[stat];
       if (report.type === statObj) {
         var found = true;
         // If |statName| is present, ensure |report| has that stat.
         // If |statVal| is present, ensure the value matches.
         if (statName) {
-          var val = statName === 'id' ? report.id : report.stat(statName);
+          var val = statName === 'id' ? report.id : report[statName];
           found = (statVal !== undefined) ? (val === statVal) : val;
         }
         if (found) {
@@ -65,8 +65,8 @@ function getStatsReport(stats, statObj, statName, statVal) {
 // Takes two stats reports and determines the rate based on two counter readings
 // and the time between them (which is in units of milliseconds).
 function computeRate(newReport, oldReport, statName) {
-  var newVal = newReport.stat(statName);
-  var oldVal = (oldReport) ? oldReport.stat(statName) : null;
+  var newVal = newReport[statName];
+  var oldVal = (oldReport) ? oldReport[statName] : null;
   if (newVal === null || oldVal === null) {
     return null;
   }


### PR DESCRIPTION
**Description**
Use the modern getStats (shimmed by adapter.js) format + fix error on Firefox.

Most media stats do not work in Firefox. I'd prefer to wait for adapter.js to shim the report name differences before changing anything. I started looking into for AppRTC only but quickly realized it's a deep rabbit hole......

**Purpose**

