### PR TITLE
Add support for GET parameter to disable video FEC.

### DIFF
--- a/src/web_app/html/params.html
+++ b/src/web_app/html/params.html
@@ -83,6 +83,7 @@
         <tr><td><a href="https://appr.tc?asbr=16000">asbr=[bitrate]</a></td><td>Set audio send bitrate</td></tr>
         <tr><td><a href="https://appr.tc?vsbr=1000">vsbr=[bitrate]</a></td><td>Set video receive bitrate</td></tr>
         <tr><td><a href="https://appr.tc?vrbr=8000">vrbr=[bitrate]</a></td><td>Set video send bitrate</td></tr>
+        <tr><td><a href="https://appr.tc?videofec=false">videofec=false</a></td><td>Turn off video FEC</td></tr>
         <tr><td><a href="https://appr.tc?opusfec=false">opusfec=false</a></td><td>Turn off Opus FEC</td></tr>
         <tr><td><a href="https://appr.tc?opusdtx=true">opusdtx=true</a></td><td>Turn on Opus DTX</td></tr>
         <tr><td><a href="https://appr.tc?opusmaxpbr=8000">opusmaxpbr=8000</a></td><td>Set the maximum sample rate that the receiver can operate, for optimal Opus encoding performance</td></tr>

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -551,6 +551,7 @@ AppController.prototype.loadUrlParams_ = function() {
   this.loadingParams_.videoSendCodec = urlParams['vsc'];
   this.loadingParams_.videoRecvBitrate = urlParams['vrbr'];
   this.loadingParams_.videoRecvCodec = urlParams['vrc'] || DEFAULT_VIDEO_CODEC;
+  this.loadingParams_.videoFec = urlParams['videofec'];
   /* jshint ignore:end */
   /* jscs: enable */
 };

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -14,7 +14,7 @@
    maybeSetAudioSendBitRate, maybeSetVideoSendBitRate,
    maybeSetAudioReceiveBitRate, maybeSetVideoSendInitialBitRate,
    maybeSetVideoReceiveBitRate, maybeSetVideoSendInitialBitRate,
-   maybeSetOpusOptions, maybeRemoveVideoFec */
+   maybeRemoveVideoFec, maybeSetOpusOptions */
 
 /* exported PeerConnectionClient */
 

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -213,6 +213,7 @@ PeerConnectionClient.prototype.setRemoteSdp_ = function(message) {
   message.sdp = maybeSetAudioSendBitRate(message.sdp, this.params_);
   message.sdp = maybeSetVideoSendBitRate(message.sdp, this.params_);
   message.sdp = maybeSetVideoSendInitialBitRate(message.sdp, this.params_);
+  message.sdp = maybeRemoveVideoFec(message.sdp, this.params_);
   this.pc_.setRemoteDescription(new RTCSessionDescription(message))
   .then(this.onSetRemoteDescriptionSuccess_.bind(this))
   .catch(this.onError_.bind(this, 'setRemoteDescription'));

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -213,7 +213,7 @@ PeerConnectionClient.prototype.setRemoteSdp_ = function(message) {
   message.sdp = maybeSetAudioSendBitRate(message.sdp, this.params_);
   message.sdp = maybeSetVideoSendBitRate(message.sdp, this.params_);
   message.sdp = maybeSetVideoSendInitialBitRate(message.sdp, this.params_);
-  message.sdp = maybeRemoveVideoFec(message.sdp, this.params_);
+  message.sdp = maybeRemoveVideoFec(message.sdp);
   this.pc_.setRemoteDescription(new RTCSessionDescription(message))
   .then(this.onSetRemoteDescriptionSuccess_.bind(this))
   .catch(this.onError_.bind(this, 'setRemoteDescription'));

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -14,7 +14,7 @@
    maybeSetAudioSendBitRate, maybeSetVideoSendBitRate,
    maybeSetAudioReceiveBitRate, maybeSetVideoSendInitialBitRate,
    maybeSetVideoReceiveBitRate, maybeSetVideoSendInitialBitRate,
-   maybeSetOpusOptions */
+   maybeSetOpusOptions, maybeRemoveVideoFec */
 
 /* exported PeerConnectionClient */
 

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -210,7 +210,6 @@ function removePayloadTypeFromMline(mLine, payloadType) {
     }
   }
   return mLine.join(' ');
-
 }
 
 function removeCodecByName(sdpLines, codec) {

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -15,7 +15,7 @@
    maybeSetAudioSendBitRate, maybePreferVideoReceiveCodec,
    maybePreferVideoSendCodec, maybeSetVideoReceiveBitRate,
    maybeSetVideoSendBitRate, maybeSetVideoSendInitialBitRate,
-   mergeConstraints, removeCodecParam*/
+   maybeRemoveVideoFec, mergeConstraints, removeCodecParam*/
 
 'use strict';
 
@@ -248,7 +248,7 @@ function removeCodecByPayloadType(sdpLines, payloadType) {
   return sdpLines;
 }
 
-function maybeRemoveVideoFec(sdp, params) {
+function maybeRemoveVideoFec(sdp) {
   var sdpLines = sdp.split('\r\n');
 
   var index = findLine(sdpLines, 'a=rtpmap', 'red');

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -216,7 +216,7 @@ function removePayloadTypeFromMline(mLine, payloadType) {
 function removeCodecByName(sdpLines, codec) {
   var index = findLine(sdpLines, 'a=rtpmap', codec);
   if (index === null) {
-    return sdpLines
+    return sdpLines;
   }
   var payloadType = getCodecPayloadTypeFromLine(sdpLines[index]);
   sdpLines.splice(index, 1);
@@ -224,11 +224,11 @@ function removeCodecByName(sdpLines, codec) {
   // Search for the video m= line and remove the codec.
   var mLineIndex = findLine(sdpLines, 'm=', 'video');
   if (mLineIndex === null) {
-    return sdpLines
+    return sdpLines;
   }
   sdpLines[mLineIndex] = removePayloadTypeFromMline(sdpLines[mLineIndex],
     payloadType);
-  return sdpLines
+  return sdpLines;
 }
 
 function removeCodecByPayloadType(sdpLines, payloadType) {
@@ -245,7 +245,7 @@ function removeCodecByPayloadType(sdpLines, payloadType) {
   }
   sdpLines[mLineIndex] = removePayloadTypeFromMline(sdpLines[mLineIndex],
     payloadType);
-  return sdpLines
+  return sdpLines;
 }
 
 function maybeRemoveVideoFec(sdp, params) {

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -261,11 +261,11 @@ function maybeRemoveVideoFec(sdp, params) {
   sdpLines = removeCodecByName(sdpLines, 'ulpfec');
 
   // Remove fmtp lines associated with red codec.
-  var index = findLine(sdpLines, 'a=fmtp', redPayloadType.toString());
+  index = findLine(sdpLines, 'a=fmtp', redPayloadType.toString());
   if (index === null) {
     return sdp;
   }
-  fmtpLine = parseFmtpLine(sdpLines[index]);
+  var fmtpLine = parseFmtpLine(sdpLines[index]);
   var rtxPayloadType = fmtpLine.pt;
   if (rtxPayloadType === null) {
     return sdp;


### PR DESCRIPTION
**Description**
Adds a GET parameter to enable filtering out the FEC/RED codecs so that apprtc can be used without FEC.

**Purpose**
Mostly for testing, but can also be useful in some situations for users who don't want to waste bandwidth on FEC.