### PR TITLE
Allow landscape orientation

### DIFF
--- a/src/web_app/html/manifest.json
+++ b/src/web_app/html/manifest.json
@@ -9,6 +9,5 @@
     }
   ],
   "start_url": "/",
-  "display": "standalone",
-  "orientation": "portrait"
+  "display": "standalone"
 }


### PR DESCRIPTION
Allow landscape orientation. Useful for large screen devices e.g. phablets and tablets.