### PR TITLE
Fixing issues with option to remove video FEC.

### DIFF
--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -202,6 +202,9 @@ PeerConnectionClient.prototype.setLocalSdpAndNotify_ =
   sessionDescription.sdp = maybeSetVideoReceiveBitRate(
     sessionDescription.sdp,
     this.params_);
+  sessionDescription.sdp = maybeRemoveVideoFec(
+    sessionDescription.sdp,
+    this.params_);
   this.pc_.setLocalDescription(sessionDescription)
   .then(trace.bind(null, 'Set session description success.'))
   .catch(this.onError_.bind(this, 'setLocalDescription'));

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -248,7 +248,7 @@ function removeCodecByPayloadType(sdpLines, payloadType) {
 }
 
 function maybeRemoveVideoFec(sdp, params) {
-  if (params.videoFec === 'true') {
+  if (params.videoFec !== 'false') {
     return sdp;
   }
 


### PR DESCRIPTION
1. Only remove if the videofec GET parameter is "false". Don't remove
   by default (if there's no GET parameter).
2. If it *is* removed, remove it from both the local and remote
   descriptions. Otherwise the remote PeerConnection thinks FEC is
   negotiated, but the local PeerConnection doesn't and is surprised
   when it sees a FEC packet.