### PR TITLE
Add real loopback calling, improve callstats initialization and some style fixes.

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -256,7 +256,6 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
 
   debug = request.get('debug')
   if debug == 'loopback':
-    # Set dtls to false as DTLS does not work for loopback.
     include_loopback_js = '<script src="/js/loopback.js"></script>'
   else:
     include_loopback_js = ''
@@ -529,7 +528,6 @@ class JoinPage(webapp2.RequestHandler):
 
   def post(self, room_id):
     is_loopback = self.request.get('debug') == 'loopback'
-
     if is_loopback:
       client_id = constants.LOOPBACK_CLIENT_ID
       memcache_client = memcache.Client()

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -257,7 +257,6 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   debug = request.get('debug')
   if debug == 'loopback':
     # Set dtls to false as DTLS does not work for loopback.
-    dtls = 'false'
     include_loopback_js = '<script src="/js/loopback.js"></script>'
   else:
     include_loopback_js = ''
@@ -388,8 +387,6 @@ def add_client_to_room(request, room_id, client_id, is_loopback):
     if occupancy == 0:
       is_initiator = True
       room.add_client(client_id, Client(is_initiator))
-      if is_loopback:
-        room.add_client(constants.LOOPBACK_CLIENT_ID, Client(False))
     else:
       is_initiator = False
       other_client = room.get_other_client(client_id)
@@ -410,7 +407,7 @@ def add_client_to_room(request, room_id, client_id, is_loopback):
     else:
       retries = retries + 1
   return {'error': error, 'is_initiator': is_initiator,
-          'messages': messages, 'room_state': str(room)}
+          'messages': messages, 'room_state': str(room), 'client_id': client_id}
 
 def remove_client_from_room(host, room_id, client_id):
   key = get_memcache_key_for_room(host, room_id)
@@ -531,8 +528,19 @@ class JoinPage(webapp2.RequestHandler):
     self.write_response('SUCCESS', params, messages)
 
   def post(self, room_id):
-    client_id = generate_random(8)
     is_loopback = self.request.get('debug') == 'loopback'
+
+    if is_loopback:
+      client_id = constants.LOOPBACK_CLIENT_ID
+      memcache_client = memcache.Client()
+      room = memcache_client.gets(
+        get_memcache_key_for_room(self.request.host_url, room_id))
+      if room is not None:
+        if room.has_client(client_id):
+          client_id = constants.LOOPBACK_CLIENT_ID_2
+    else:
+      client_id = generate_random(8)
+
     result = add_client_to_room(self.request, room_id, client_id, is_loopback)
     if result['error'] is not None:
       logging.info('Error adding client to room: ' + result['error'] + \
@@ -541,7 +549,7 @@ class JoinPage(webapp2.RequestHandler):
       return
 
     self.write_room_parameters(
-        room_id, client_id, result['messages'], result['is_initiator'])
+        room_id, result['client_id'], result['messages'], result['is_initiator'])
     logging.info('User ' + client_id + ' joined room ' + room_id)
     logging.info('Room ' + room_id + ' has state ' + result['room_state'])
 

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -9,7 +9,9 @@ import os
 ROOM_MEMCACHE_EXPIRATION_SEC = 60 * 60 * 24
 MEMCACHE_RETRY_LIMIT = 100
 
+# Client ID's for the loopback peerconnections.
 LOOPBACK_CLIENT_ID = 'LOOPBACK_CLIENT_ID'
+LOOPBACK_CLIENT_ID_2 = 'LOOPBACK_CLIENT_ID_2'
 
 # TODO: Remove once clients support ICE_SERVER.
 TURN_BASE_URL = 'https://computeengineondemand.appspot.com'

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -252,6 +252,7 @@ AppController.prototype.hangup_ = function() {
   // Reset key and mouse event handlers.
   document.onkeypress = null;
   window.onmousemove = null;
+  this.remoteVideo_.srcObject = null;
 };
 
 AppController.prototype.onRemoteHangup_ = function() {
@@ -374,6 +375,8 @@ AppController.prototype.transitionToWaiting_ = function() {
 AppController.prototype.transitionToDone_ = function() {
   // Stop waiting for remote video.
   this.remoteVideo_.oncanplay = undefined;
+  // Rotate back the video div for rejoin and new room situations.
+  this.deactivate_(this.videosDiv_);
   this.deactivate_(this.localVideo_);
   this.deactivate_(this.remoteVideo_);
   this.deactivate_(this.miniVideo_);

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-var Call = function(params) {
+var Call = function(params, doNotRequestMediaAndIceServers) {
   this.params_ = params;
   this.roomServer_ = params.roomServer || '';
 
@@ -42,7 +42,9 @@ var Call = function(params) {
 
   this.getMediaPromise_ = null;
   this.getIceServersPromise_ = null;
-  this.requestMediaAndIceServers_();
+  if (!doNotRequestMediaAndIceServers) {
+    this.requestMediaAndIceServers_();
+  }
 };
 
 Call.prototype.requestMediaAndIceServers_ = function() {
@@ -56,9 +58,6 @@ Call.prototype.isInitiator = function() {
 
 Call.prototype.start = function(roomId) {
   this.connectToRoom_(roomId);
-  if (this.params_.isLoopback) {
-    setupLoopback(this.params_.wssUrl, roomId);
-  }
 };
 
 Call.prototype.queueCleanupMessages_ = function() {
@@ -154,32 +153,32 @@ Call.prototype.hangup = function(async) {
   var steps = [];
   steps.push({
     step: function() {
-        // Send POST request to /leave.
-        var path = this.getLeaveUrl_();
-        return sendUrlRequest('POST', path, async);
-      }.bind(this),
+      // Send POST request to /leave.
+      var path = this.getLeaveUrl_();
+      return sendUrlRequest('POST', path, async);
+    }.bind(this),
     errorString: 'Error sending /leave:'
   });
   steps.push({
     step: function() {
-        // Send bye to the other client.
-        this.channel_.send(JSON.stringify({type: 'bye'}));
-      }.bind(this),
+      // Send bye to the other client.
+      this.channel_.send(JSON.stringify({type: 'bye'}));
+    }.bind(this),
     errorString: 'Error sending bye:'
   });
   steps.push({
     step: function() {
-        // Close signaling channel.
-        return this.channel_.close(async);
-      }.bind(this),
+      // Close signaling channel.
+      return this.channel_.close(async);
+    }.bind(this),
     errorString: 'Error closing signaling channel:'
   });
   steps.push({
     step: function() {
-        this.params_.previousRoomId = this.params_.roomId;
-        this.params_.roomId = null;
-        this.params_.clientId = null;
-      }.bind(this),
+      this.params_.previousRoomId = this.params_.roomId;
+      this.params_.roomId = null;
+      this.params_.clientId = null;
+    }.bind(this),
     errorString: 'Error setting params:'
   });
 
@@ -232,7 +231,6 @@ Call.prototype.onRemoteHangup = function() {
     this.pcClient_.close();
     this.pcClient_ = null;
   }
-
   this.startSignaling_();
 };
 
@@ -322,7 +320,6 @@ Call.prototype.connectToRoom_ = function(roomId) {
   // already registered with GAE.
   Promise.all([channelPromise, joinPromise]).then(function() {
     this.channel_.register(this.params_.roomId, this.params_.clientId);
-
     // We only start signaling after we have registered the signaling channel
     // and have media and TURN. Since we send candidates as soon as the peer
     // connection generates them we need to wait for the signaling channel to be
@@ -491,6 +488,13 @@ Call.prototype.startSignaling_ = function() {
       this.pcClient_.startAsCaller(this.params_.offerOptions);
     } else {
       this.pcClient_.startAsCallee(this.params_.messages);
+    }
+    // Setup the remote loopback peerconnection client. Give the first
+    // peerConnection some time to setup.
+    if (this.params_.isLoopback && this.params_.isInitiator) {
+      setTimeout(function() {
+        setupLoopback(this.params_);
+      }.bind(this), 2000);
     }
     this.maybeReportGetUserMediaErrors_();
   }.bind(this))

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -42,6 +42,8 @@ var Call = function(params, doNotRequestMediaAndIceServers) {
 
   this.getMediaPromise_ = null;
   this.getIceServersPromise_ = null;
+  // Only request ICE servers and getUserMedia for p2p calls and the 1st
+  // loopback peerConnection.
   if (!doNotRequestMediaAndIceServers) {
     this.requestMediaAndIceServers_();
   }

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -15,7 +15,8 @@
 /* exported Call */
 
 'use strict';
-
+// doNotRequestMediaAndIceServers should be set to true if getUserMedia and Ice
+// servers should not be request.
 var Call = function(params, doNotRequestMediaAndIceServers) {
   this.params_ = params;
   this.roomServer_ = params.roomServer || '';
@@ -491,12 +492,8 @@ Call.prototype.startSignaling_ = function() {
     } else {
       this.pcClient_.startAsCallee(this.params_.messages);
     }
-    // Setup the remote loopback peerconnection client. Give the first
-    // peerConnection some time to setup.
     if (this.params_.isLoopback && this.params_.isInitiator) {
-      setTimeout(function() {
-        setupLoopback(this.params_);
-      }.bind(this), 2000);
+      setupLoopback(this.params_);
     }
     this.maybeReportGetUserMediaErrors_();
   }.bind(this))

--- a/src/web_app/js/loopback.js
+++ b/src/web_app/js/loopback.js
@@ -12,74 +12,62 @@
 
 'use strict';
 
-// We handle the loopback case by making a second connection to the WSS so that
-// we receive the same messages that we send out. When receiving an offer we
-// convert that offer into an answer message. When receiving candidates we
-// echo back the candidate. Answer is ignored because we should never receive
-// one while in loopback. Bye is ignored because there is no work to do.
-var loopbackWebSocket = null;
-var LOOPBACK_CLIENT_ID = 'loopback_client_id';
-function setupLoopback(wssUrl, roomId) {
-  if (loopbackWebSocket) {
-    loopbackWebSocket.close();
+function setupLoopback(params) {
+  trace('Setting up loopback peerConnection client.');
+  // Reuse the parameters from the first peerconnection and modify what's needed
+  // for the 2nd loopback peerconnection.
+  var params_ = JSON.parse(JSON.stringify(params));
+  params_.clientId = 'LOOPBACK_CLIENT_ID_2';
+  params_.isInitiator = false;
+  params_.mediaConstraints.audio = false;
+  params_.mediaConstraints.video = false;
+  var call = new Call(params_, true);
+
+  // Dereference the call object.
+  function deleteCall() {
+    call = null;
   }
-  trace('Setting up loopback WebSocket.');
-  // TODO(tkchin): merge duplicate code once SignalingChannel abstraction
-  // exists.
-  loopbackWebSocket = new WebSocket(wssUrl);
 
-  var sendLoopbackMessage = function(message) {
-    var msgString = JSON.stringify({
-      cmd: 'send',
-      msg: JSON.stringify(message)
-    });
-    loopbackWebSocket.send(msgString);
-  };
-
-  loopbackWebSocket.onopen = function() {
-    trace('Loopback WebSocket opened.');
-    var registerMessage = {
-      cmd: 'register',
-      roomid: roomId,
-      clientid: LOOPBACK_CLIENT_ID
-    };
-    loopbackWebSocket.send(JSON.stringify(registerMessage));
-  };
-
-  loopbackWebSocket.onmessage = function(event) {
-    var wssMessage;
-    var message;
-    try {
-      wssMessage = JSON.parse(event.data);
-      message = JSON.parse(wssMessage.msg);
-    } catch (e) {
-      trace('Error parsing JSON: ' + event.data);
-      return;
+  // Hangup the loopback peerconnection properly since the UI only controls the
+  // first peerconnection.
+  call.onremotehangup = function() {
+    this.hangup(true);
+    this.startTime = null;
+    if (this.pcClient_) {
+      this.pcClient_.close();
+      this.pcClient_ = null;
     }
-    if (wssMessage.error) {
-      trace('WSS error: ' + wssMessage.error);
-      return;
+    deleteCall();
+  }.bind(call);
+
+  // Add the remote stream from peerConnection 1 as a local stream
+  // for peerConnection 2 (loopback) before sending an answer to avoid renegotiation
+  // since peerConnection 2 does not have a access to the stream until
+  // peerConnection 1 has added it.
+  call.onremotestreamadded = function(event) {
+    if (this.params_.clientId === 'LOOPBACK_CLIENT_ID_2') {
+      // Since this fired once per track we need to make sure it will only add
+      // the stream once.
+      if (this.pcClient_.loopBackStream === null) {
+        // 2nd peerConnection should not be the initiator.
+        if (!this.params_.isInitiator_) {
+          this.pcClient_.loopBackStream = event.clone();
+          // Disable tracks on the remote tracks of the remote stream otherwise
+          // it will be played back by the Chrome mixer as well.
+          event.getAudioTracks()[0].enabled = false;
+          this.pcClient_.pc_.addStream(this.pcClient_.loopBackStream);
+          this.pcClient_.doAnswer_();
+        }
+      }
     }
-    if (message.type === 'offer') {
-      var loopbackAnswer = wssMessage.msg;
-      loopbackAnswer = loopbackAnswer.replace('"offer"', '"answer"');
-      loopbackAnswer =
-          loopbackAnswer.replace('a=ice-options:google-ice\\r\\n', '');
-      // As of Chrome M51, an additional crypto method has been added when
-      // using SDES. This works in a P2P due to the negotiation phase removes
-      // this line but for loopback where we reuse the offer, that is skipped
-      // and remains in the answer and breaks the call.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=616263
-      loopbackAnswer = loopbackAnswer
-          .replace(/a=crypto:0 AES_CM_128_HMAC_SHA1_32\sinline:.{44}/, '');
-      sendLoopbackMessage(JSON.parse(loopbackAnswer));
-    } else if (message.type === 'candidate') {
-      sendLoopbackMessage(message);
-    }
+  }.bind(call);
+
+  // Make sure to shutdown the loopback peerconnection properly when a user
+  // closes the tab.
+  window.onbeforeunload = function() {
+    call.hangup.bind(call, false);
   };
 
-  loopbackWebSocket.onclose = function(event) {
-    trace('Loopback WebSocket closed with code:' + event.code + ' reason:' +
-          event.reason);
-  };
+  // Start the loopback peerconnection.
+  call.start(params_.roomId);
 }

--- a/src/web_app/js/loopback.js
+++ b/src/web_app/js/loopback.js
@@ -55,8 +55,8 @@ function setupLoopback(params) {
         // 2nd peerConnection should not be the initiator.
         if (!this.params_.isInitiator_) {
           this.pcClient_.loopBackStream = event.clone();
-          // Disable tracks on the remote tracks of the remote stream otherwise
-          // it will be played back by the Chrome mixer as well.
+          // Disable audio tracks on the remote tracks of the remote stream
+          // otherwise it will be played back by the Chrome mixer as well.
           event.getAudioTracks()[0].enabled = false;
           this.pcClient_.pc_.addStream(this.pcClient_.loopBackStream);
           this.pcClient_.doAnswer_();

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -458,7 +458,7 @@ PeerConnectionClient.prototype.initCallstats_ = function(successCallback) {
   trace('Init callstats.');
   var appId = this.params_.callstatsParams.appId;
   var appSecret = this.params_.callstatsParams.appSecret;
-  if (!appId || !appSecret) {
+  if (!appId || appId === 'none' || !appSecret || appSecret === 'none') {
     trace('Could not init callstats due to missing App ID and/or API key');
     return;
   }

--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -28,7 +28,6 @@
 var PeerConnectionClient = function(params, startTime) {
   this.params_ = params;
   this.startTime_ = startTime;
-
   trace('Creating RTCPeerConnnection with:\n' +
     '  config: \'' + JSON.stringify(params.peerConnectionConfig) + '\';\n' +
     '  constraints: \'' + JSON.stringify(params.peerConnectionConstraints) +
@@ -61,6 +60,7 @@ var PeerConnectionClient = function(params, startTime) {
   this.onsignalingstatechange = null;
 
   this.callstatsInit = false;
+  this.loopBackStream = null;
 };
 
 // Set up audio and video regardless of what devices are present.
@@ -160,6 +160,12 @@ PeerConnectionClient.prototype.close = function() {
   this.pc_.close();
   this.pc_ = null;
   this.callstatsInit = false;
+  if (this.loopBackStream !== null) {
+    this.loopBackStream.getTracks().forEach(function(track) {
+      track.stop();
+    });
+    this.loopBackStream = null;
+  }
 };
 
 PeerConnectionClient.prototype.getPeerConnectionStates = function() {
@@ -254,7 +260,12 @@ PeerConnectionClient.prototype.processSignalingMessage_ = function(message) {
       return;
     }
     this.setRemoteSdp_(message);
-    this.doAnswer_();
+    // For the loopback peerconnection, the answer is called in the
+    // onremotestreamadded event to ensure the remote stream is available for
+    // cloning before answering..
+    if (this.params_.clientId !== 'LOOPBACK_CLIENT_ID_2') {
+      this.doAnswer_();
+    }
   } else if (message.type === 'answer' && this.isInitiator_) {
     if (this.pc_.signalingState !== 'have-local-offer') {
       trace('ERROR: remote answer received in unexpected state: ' +
@@ -389,7 +400,7 @@ PeerConnectionClient.prototype.onError_ = function(tag, error) {
 };
 
 PeerConnectionClient.prototype.isCallstatsInitialized_ = function() {
-  if (!this.callstats && !this.callstatsInit) {
+  if (!this.callstats || !this.callstatsInit) {
     trace('Callstats not initilized.');
     return false;
   } else {
@@ -442,16 +453,26 @@ PeerConnectionClient.prototype.reportErrorToCallstats =
   }
 };
 
+// Try to init the callstats library.
 PeerConnectionClient.prototype.initCallstats_ = function(successCallback) {
   trace('Init callstats.');
+  var appId = this.params_.callstatsParams.appId;
+  var appSecret = this.params_.callstatsParams.appSecret;
+  if (!appId || !appSecret) {
+    trace('Could not init callstats due to missing App ID and/or API key');
+    return;
+  }
+  // Check dependencies.
+  if (typeof io !== 'function' || typeof jsSHA !== 'function')  {
+    trace('Callstats dependencies missing, stats will not be setup.');
+    return;
+  }
   // jscs:disable requireCapitalizedConstructors
   /* jshint newcap: false */
   this.callstats = new callstats(null, io, jsSHA);
   // jscs:enable requireCapitalizedConstructors
   /* jshint newcap: true */
 
-  var appId = this.params_.callstatsParams.appId;
-  var appSecret = this.params_.callstatsParams.appSecret;
   this.userId = this.params_.roomId + (this.isInitiator_ ? '-0' : '-1');
   var statsCallback = null;
   var configParams = {
@@ -467,25 +488,18 @@ PeerConnectionClient.prototype.initCallstats_ = function(successCallback) {
     }
     trace('Init status: ' + status + ' msg: ' + msg);
   }.bind(this);
+
   this.callstats.initialize(appId, appSecret, this.userId, callback,
       statsCallback, configParams);
 };
 
 // Setup the callstats api and attach it to the peerconnection.
 PeerConnectionClient.prototype.setupCallstats_ = function() {
-  // Check dependencies.
-  if (typeof io !== 'function' && typeof jsSHA !== 'function')  {
-    trace('Callstats dependencies missing, stats will not be setup.');
-    return;
-  }
-
   // Need to catch the error otherwise the peerConnection creation
   // will fail.
   try {
     // Authenticate with the callstats backend.
     var successCallback = function() {
-      this.callStatsAttachedToPc = false;
-
       trace('Set up callstats.');
       this.conferenceId = this.params_.roomId;
       this.remoteUserId = this.params_.roomId +

--- a/src/web_app/js/peerconnectionclient_test.js
+++ b/src/web_app/js/peerconnectionclient_test.js
@@ -327,10 +327,10 @@ PeerConnectionClientTest.prototype.testOnRemoteStreamAdded = function() {
   this.pcClient.onremotestreamadded = onRemoteStreamAdded;
 
   var event = {
-    stream: 'stream'
+    streams: ['stream']
   };
-  peerConnections[0].onaddstream(event);
-  assertEquals(event.stream, stream);
+  peerConnections[0].ontrack(event);
+  assertEquals(event.streams[0], stream);
 };
 
 PeerConnectionClientTest.prototype.testOnSignalingStateChange = function() {


### PR DESCRIPTION
**Description**
* Fixes #34 #312 (Removes single peerconnection loopback using SDES which is deprecated)
* Setup a 2nd Call constructor without any media to act as a loopback peerconnection which clones the remote stream and adds it back as a local stream which the 1st peerconnection receives and processes as usual.
* Make the callstats init more robust (I know it's a bit messy to have it in the same PR but I encountered lots of issues while testing this thus had to fix it).
* Also fixed the onstream test to use ontrack instead.
* Fixed the transition for rejoin and new room calls (it never flipped back the video tags between calls)
* Fixed some indentations here and there.

**Purpose**
Deprecate SDES loopback and make callstats init more robust.
