### PR TITLE
Redirect if URL is not appr.tc and redirect is not handled by ISP

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -553,8 +553,7 @@ class MainPage(webapp2.RequestHandler):
 
   def get(self):
     """Renders index.html."""
-    if self.request.headers['Host'] == 'apprtc.net':
-      webapp2.redirect('https://www.apprtc.net', permanent=True)
+    checkIfRedirect(self);
     # Parse out parameters from request.
     params = get_room_parameters(self.request, None, None, None)
     # room_id/room_link will not be included in the returned parameters
@@ -569,6 +568,7 @@ class RoomPage(webapp2.RequestHandler):
 
   def get(self, room_id):
     """Renders index.html or full.html."""
+    checkIfRedirect(self)
     # Check if room is full.
     room = memcache.get(
         get_memcache_key_for_room(self.request.host_url, room_id))
@@ -590,6 +590,20 @@ class ParamsPage(webapp2.RequestHandler):
     params = get_room_parameters(self.request, None, None, None)
     self.response.write(json.dumps(params))
 
+def checkIfRedirect(self):
+  REDIRECT_DOMAINS = [
+    'apprtc.appspot.com', 'apprtc.webrtc.org', 'www.appr.tc'
+  ]
+  ARGUMENTS = self.request.arguments()
+  parsed_args = ''
+  if self.request.headers['Host'] in REDIRECT_DOMAINS:
+    webapp2.redirect('https://appr.tc', permanent=True)
+    for argument in ARGUMENTS:
+      if parsed_args == '':
+        parsed_args += '?'
+      parsed_args += argument + '&'
+    redirect_url = 'https://appr.tc' + self.request.path + parsed_args
+    webapp2.redirect(redirect_url, permanent=True, abort=True)
 
 app = webapp2.WSGIApplication([
     ('/', MainPage),

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -591,18 +591,16 @@ class ParamsPage(webapp2.RequestHandler):
     self.response.write(json.dumps(params))
 
 def checkIfRedirect(self):
-  REDIRECT_DOMAINS = [
-    'apprtc.appspot.com', 'apprtc.webrtc.org', 'www.appr.tc'
-  ]
-  ARGUMENTS = self.request.arguments()
   parsed_args = ''
-  if self.request.headers['Host'] in REDIRECT_DOMAINS:
-    webapp2.redirect('https://appr.tc', permanent=True)
-    for argument in ARGUMENTS:
+  if self.request.headers['Host'] in constants.REDIRECT_DOMAINS:
+    for argument in self.request.arguments():
+      parameter = '=' + self.request.get(argument)
       if parsed_args == '':
         parsed_args += '?'
-      parsed_args += argument + '&'
-    redirect_url = 'https://appr.tc' + self.request.path + parsed_args
+      else:
+        parsed_args += '&'
+      parsed_args += argument + parameter
+    redirect_url = constants.REDIRECT_URL + self.request.path + parsed_args
     webapp2.redirect(redirect_url, permanent=True, abort=True)
 
 app = webapp2.WSGIApplication([

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -6,6 +6,13 @@ This module contains the constants used in AppRTC Python modules.
 """
 import os
 
+# Deprecated domains which we should to redirect to REDIRECT_URL.
+REDIRECT_DOMAINS =  [
+  'apprtc.appspot.com', 'apprtc.webrtc.org', 'www.appr.tc', 'localhost:8080'
+]
+# URL which we should redirect to if matching in REDIRECT_DOMAINS.
+REDIRECT_URL = 'https://appr.tc'
+
 ROOM_MEMCACHE_EXPIRATION_SEC = 60 * 60 * 24
 MEMCACHE_RETRY_LIMIT = 100
 


### PR DESCRIPTION
**Description**
Redirect old URL's not handled by the ISP to appr.tc and make sure the path and URL paramters tag along.

Fixes #221

**Purpose**
Make everyone use appr.tc.
