### PR TITLE
Add Turn/Stun server override in constants.py

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -265,6 +265,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   # TODO(tkchin): We want to provide a ICE request url on the initial get,
   # but we don't provide client_id until a join. For now just generate
   # a random id, but we should make this better.
+  # TODO(jansson): Remove this once CEOD is deprecated.
   username = client_id if client_id is not None else generate_random(9)
   if len(ice_server_base_url) > 0:
     ice_server_url = constants.ICE_SERVER_URL_TEMPLATE % \
@@ -272,8 +273,12 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   else:
     ice_server_base_url = ''
 
+  # TODO(jansson): Remove this once CEOD is deprecated.
   turn_url = constants.TURN_URL_TEMPLATE % \
       (constants.TURN_BASE_URL, username, constants.CEOD_KEY)
+  # If defined it will override the ICE server provider and use the specified
+  # turn servers directly.
+  turn_server_override = constants.TURN_SERVER_OVERRIDE
 
   pc_config = make_pc_config(ice_transports)
   pc_constraints = make_pc_constraints(dtls, dscp, ipv6)
@@ -293,6 +298,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     'pc_constraints': json.dumps(pc_constraints),
     'offer_options': json.dumps(offer_options),
     'media_constraints': json.dumps(media_constraints),
+    'turn_server_override': turn_server_override,
     'turn_url': turn_url,
     'ice_server_url': ice_server_url,
     'ice_server_transports': ice_server_transports,

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -11,7 +11,28 @@ MEMCACHE_RETRY_LIMIT = 100
 
 LOOPBACK_CLIENT_ID = 'LOOPBACK_CLIENT_ID'
 
-# TODO: Remove once clients support ICE_SERVER.
+# Turn/Stun server override. This allows AppRTC to connect to turn servers
+# directly rather than retrieving them from an ICE server provider.
+TURN_SERVER_OVERRIDE = []
+# Enable by uncomment below and comment out above, then specify turn and stun
+# servers below.
+# TURN_SERVER_OVERRIDE = [
+#   {
+#     "urls": [
+#       "turn:hostname/IpToTurnServer:19305?transport=udp",
+#       "turn:hostname/IpToTurnServer:19305?transport=tcp"
+#     ],
+#     "username": "TurnServerUsername",
+#     "credential": "TurnServerCredentials"
+#   },
+#   {
+#     "urls": [
+#       "stun:hostname/IpToStunServer:19302"
+#     ]
+#   }
+# ]
+
+# TODO(jansson): Remove once AppRTCDemo on iOS supports ICE_SERVER.
 TURN_BASE_URL = 'https://computeengineondemand.appspot.com'
 TURN_URL_TEMPLATE = '%s/turn?username=%s&key=%s'
 CEOD_KEY = '4080218913'

--- a/src/web_app/html/index_template.html
+++ b/src/web_app/html/index_template.html
@@ -153,6 +153,7 @@
       wssUrl: '{{ wss_url }}',
       wssPostUrl: '{{ wss_post_url }}',
       bypassJoinConfirmation: {{ bypass_join_confirmation }},
+      turnServerOverride: {{ turn_server_override }},
       versionInfo: {{ version_info }},
       callstatsParams: {{ callstats_params}}
     };

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -375,7 +375,8 @@ Call.prototype.maybeGetMedia_ = function() {
 Call.prototype.maybeGetIceServers_ = function() {
   var shouldRequestIceServers =
       (this.params_.iceServerRequestUrl &&
-      this.params_.iceServerRequestUrl.length > 0);
+      this.params_.iceServerRequestUrl.length > 0 &&
+      this.params_.turnServerOverride.length === 0);
 
   var iceServerPromise = null;
   if (shouldRequestIceServers) {
@@ -401,7 +402,18 @@ Call.prototype.maybeGetIceServers_ = function() {
           trace(error.message);
         }.bind(this));
   } else {
-    iceServerPromise = Promise.resolve();
+    if (this.params_.turnServerOverride.length === 0) {
+      iceServerPromise = Promise.resolve();
+    } else {
+      // if turnServerOverride is not empty it will be used for
+      // turn/stun servers.
+      iceServerPromise = new Promise(function(resolve) {
+        this.params_.peerConnectionConfig.iceServers =
+            this.params_.turnServerOverride;
+        resolve();
+      }.bind(this))
+    }
+
   }
   return iceServerPromise;
 };

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -411,7 +411,7 @@ Call.prototype.maybeGetIceServers_ = function() {
         this.params_.peerConnectionConfig.iceServers =
             this.params_.turnServerOverride;
         resolve();
-      }.bind(this))
+      }.bind(this));
     }
 
   }


### PR DESCRIPTION
**Description**
Lots of people wants to use turn/stun servers directly rather than having a webserver serving them as a JSON (aka ICE Server provider).

I will create a follow up PR updating the instructions (easier to create links when the code is in the repo).

**Purpose**
Make it easier to use turn/stun server directly
