### PR TITLE
room link fix

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -311,7 +311,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   }
 
   if room_id is not None:
-    room_link = request.host_url + '/r/' + room_id
+    room_link = "//"+request.host + '/r/' + room_id
     room_link = append_url_arguments(request, room_link)
     params['room_id'] = room_id
     params['room_link'] = room_link


### PR DESCRIPTION
**Description**
Create a room link without the schema. (//hostname/path) instead of (http://hostname/path) so that it can be easily integrated with a reverse https proxy 

**Purpose**
