### PR TITLE
Adding back TLS1.x ciphers to increase compatability

### DIFF
--- a/src/collider/collider/collider.go
+++ b/src/collider/collider/collider.go
@@ -57,6 +57,9 @@ func (c *Collider) Run(p int, useTls bool) {
 				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 			},
 			PreferServerCipherSuites: true,
 		}

--- a/src/web_app/js/sdputils_test.js
+++ b/src/web_app/js/sdputils_test.js
@@ -14,17 +14,17 @@
 'use strict';
 
 describe('Sdp utils test', function() {
-  var SDP_WITH_AUDIO_CODECS =
-    ['v=0',
-     'm=audio 9 RTP/SAVPF 111 103 104 0 9',
-     'a=rtcp-mux',
-     'a=rtpmap:111 opus/48000/2',
-     'a=fmtp:111 minptime=10',
-     'a=rtpmap:103 ISAC/16000',
-     'a=rtpmap:9 G722/8000',
-     'a=rtpmap:0 PCMU/8000',
-     'a=rtpmap:8 PCMA/8000',
-    ].join('\r\n');
+  var SDP_WITH_AUDIO_CODECS = [
+    'v=0',
+    'm=audio 9 RTP/SAVPF 111 103 104 0 9',
+    'a=rtcp-mux',
+    'a=rtpmap:111 opus/48000/2',
+    'a=fmtp:111 minptime=10',
+    'a=rtpmap:103 ISAC/16000',
+    'a=rtpmap:9 G722/8000',
+    'a=rtpmap:0 PCMU/8000',
+    'a=rtpmap:8 PCMA/8000',
+  ].join('\r\n');
 
   it('moves Isac 16K to default when preferred', function() {
     var result = maybePreferCodec(SDP_WITH_AUDIO_CODECS, 'audio', 'send',


### PR DESCRIPTION
**Description**
Some WebSocket libraries when used on older Android versions do not support TLS 1.2.

**Purpose**
Increase comparability....