### PR TITLE
handle room full state by returning to room selection state.

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -548,6 +548,11 @@ Call.prototype.joinRoom_ = function() {
         // selection state.
         // When room is full, responseObj.result === 'FULL'
         reject(Error('Registration error: ' + responseObj.result));
+        if (responseObj.result === 'FULL') {
+          var getPath = this.roomServer_ + '/r/' +
+              this.params_.roomId + window.location.search;
+          window.location.assign(getPath);
+        }
         return;
       }
       trace('Joined the room.');


### PR DESCRIPTION
**Description**
Handle room full state by returning to room selection state.
Once a room is full, the same user interface will be displayed, whether  doing POST `roomserver/join/roomId` or GET `roomserver/r/roomId`

**Purpose**
When a room is full, new requests to join the room result in the same user interface

