### PR TITLE
Improved app.yaml

### DIFF
--- a/src/app_engine/app.yaml
+++ b/src/app_engine/app.yaml
@@ -1,5 +1,3 @@
-application: apprtc
-version: 9
 runtime: python27
 threadsafe: true
 api_version: 1


### PR DESCRIPTION
Latest documentation on app.yaml recommends removing application and version element.
https://cloud.google.com/appengine/docs/standard/python/config/appref
At least for my case, gcloud would complain if these elements are present.

For setting up environment variables, I haven't found gcloud equivalent of appcfg.py --env_variable.
Since it is not clear for someone not familiar with app engine that appcfg.py is not available from the new Google Cloud SDK, I would say removing these instructions reduces confusion.