### PR TITLE
Fixing variable name

### DIFF
--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -279,7 +279,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     ice_server_url = constants.ICE_SERVER_URL_TEMPLATE % \
         (ice_server_base_url, constants.ICE_SERVER_API_KEY)
   else:
-    ice_server_base_url = ''
+    ice_server_url = ''
 
   # TODO(jansson): Remove this once CEOD is deprecated.
   turn_url = constants.TURN_URL_TEMPLATE % \


### PR DESCRIPTION
**Description**
As reported in https://github.com/webrtc/apprtc/issues/437, AppRTC does not work without an ICE server because
of a wrong assignment.

This pull reuqest should fix.

**Purpose**
Fixing https://github.com/webrtc/apprtc/issues/437.