### PR TITLE
Update getstats and remove callstats deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
 
-before_install:
-  - npm install -g npm@'>=3.0.0'
-
 before_script:
   - npm install
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/cucumber_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1600x1200x16

--- a/src/web_app/html/index_template.html
+++ b/src/web_app/html/index_template.html
@@ -30,8 +30,6 @@
   <link rel="stylesheet" href="/css/main.css">
   <!-- callstats dependencies: http://www.callstats.io/api/#integrating-with-your-sdk -->
   <script src="/callstats/callstats.min.js"></script>
-  <script src="/callstats/sha.js"></script>
-  <script src="/callstats/socket.io.js"></script>
 
 </head>
 

--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -146,8 +146,8 @@ AppController.prototype.createCall_ = function() {
   var privacyLinks = $(UI_CONSTANTS.privacyLinks);
   this.hide_(privacyLinks);
   this.call_ = new Call(this.loadingParams_);
-  this.infoBox_ = new InfoBox($(UI_CONSTANTS.infoDiv),
-      this.remoteVideo_, this.call_, this.loadingParams_.versionInfo);
+  this.infoBox_ = new InfoBox($(UI_CONSTANTS.infoDiv), this.call_,
+      this.loadingParams_.versionInfo);
 
   var roomErrors = this.loadingParams_.errorMessages;
   var roomWarnings = this.loadingParams_.warningMessages;
@@ -286,6 +286,8 @@ AppController.prototype.onRemoteStreamAdded_ = function(stream) {
   this.deactivate_(this.sharingDiv_);
   trace('Remote stream added.');
   this.remoteVideo_.srcObject = stream;
+  this.infoBox_.getRemoteTrackIds(stream);
+
 
   if (this.remoteVideoResetTimer_) {
     clearTimeout(this.remoteVideoResetTimer_);
@@ -296,6 +298,7 @@ AppController.prototype.onRemoteStreamAdded_ = function(stream) {
 AppController.prototype.onLocalStreamAdded_ = function(stream) {
   trace('User has granted access to local media.');
   this.localStream_ = stream;
+  this.infoBox_.getLocalTrackIds(this.localStream_);
 
   if (!this.roomSelection_) {
     this.attachLocalStream_();

--- a/src/web_app/js/infobox.js
+++ b/src/web_app/js/infobox.js
@@ -177,11 +177,11 @@ InfoBox.prototype.updateInfoDiv = function() {
         localTypePref = connectionStats.localPriority >> 24;
       }
       contents += this.buildLine_('LocalAddr', localAddr +
-          ' (' + localAddrType + (typeof localTypePref !== undefined ?
-          '' + formatTypePreference(localTypePref) : '') + ')');
+          ' (' + localAddrType + (typeof localTypePref !== undefined ? '' +
+          formatTypePreference(localTypePref) : '') + ')');
       contents += this.buildLine_('LocalPort', localPort);
-      contents += this.buildLine_('RemoteAddr', remoteAddr +
-          ' (' + remoteAddrType + ')');
+      contents += this.buildLine_('RemoteAddr', remoteAddr + ' (' +
+          remoteAddrType + ')');
       contents += this.buildLine_('RemotePort', remotePort);
     }
     contents += this.buildLine_();

--- a/src/web_app/js/stats.js
+++ b/src/web_app/js/stats.js
@@ -9,7 +9,7 @@
 /* More information about these options at jshint.com/docs/options */
 
 /* exported computeBitrate, computeE2EDelay, computeRate,
-   extractStatAsInt, refreshStats */
+   enumerateStats, extractStatAsInt, refreshStats */
 
 'use strict';
 
@@ -61,6 +61,274 @@ function getStatsReport(stats, statObj, statName, statVal) {
     });
   }
   return result;
+}
+
+// Enumerates the new standard compliant stats using local and remote track ids.
+function enumerateStats(stats, localTrackIds, remoteTrackIds) {
+  // Create an object structure with all the needed stats and types that we care
+  // about. This allows to map the getStats stats to other stats names.
+  var statsObject = {
+    audio: {
+      local: {
+        audioLevel: 0.0,
+        bytesSent: 0,
+        clockRate: 0,
+        codecId: '',
+        mimeType: '',
+        packetsSent: 0,
+        payloadType: 0,
+        timestamp: 0.0,
+        trackId: '',
+        transportId: '',
+      },
+      remote: {
+        audioLevel: 0.0,
+        bytesReceived: 0,
+        clockRate: 0,
+        codecId: '',
+        fractionLost: 0,
+        jitter: 0,
+        mimeType: '',
+        packetsLost: 0,
+        packetsReceived: 0,
+        payloadType: 0,
+        timestamp: 0.0,
+        trackId: '',
+        transportId: '',
+      }
+    },
+    video: {
+      local: {
+        bytesSent: 0,
+        clockRate: 0,
+        codecId: '',
+        firCount: 0,
+        framesEncoded: 0,
+        frameHeight: 0,
+        framesSent: 0,
+        frameWidth: 0,
+        nackCount: 0,
+        packetsSent: 0,
+        payloadType: 0,
+        pliCount: 0,
+        qpSum: 0,
+        timestamp: 0.0,
+        trackId: '',
+        transportId: '',
+      },
+      remote: {
+        bytesReceived: 0,
+        clockRate: 0,
+        codecId: '',
+        firCount: 0,
+        fractionLost: 0,
+        frameHeight: 0,
+        framesDecoded: 0,
+        framesDropped: 0,
+        framesReceived: 0,
+        frameWidth: 0,
+        nackCount: 0,
+        packetsLost: 0,
+        packetsReceived: 0,
+        payloadType: 0,
+        pliCount: 0,
+        qpSum: 0,
+        timestamp: 0.0,
+        trackId: '',
+        transportId: '',
+      }
+    },
+    connection: {
+      availableOutgoingBitrate: 0,
+      bytesReceived: 0,
+      bytesSent: 0,
+      consentRequestsSent: 0,
+      currentRoundTripTime: 0.0,
+      localCandidateId: '',
+      localCandidateType: '',
+      localIp: '',
+      localPort: 0,
+      localPriority: 0,
+      localProtocol: '',
+      remoteCandidateId: '',
+      remoteCandidateType: '',
+      remoteIp: '',
+      remotePort: 0,
+      remotePriority: 0,
+      remoteProtocol: '',
+      requestsReceived: 0,
+      requestsSent: 0,
+      responsesReceived: 0,
+      responsesSent: 0,
+      timestamp: 0.0,
+      totalRoundTripTime: 0.0,
+    }
+  };
+
+  // Need to find the codec, local and remote ID's first.
+  if (stats) {
+    stats.forEach(function(report, stat) {
+      switch(report.type) {
+        case 'outbound-rtp':
+          if (report.hasOwnProperty('trackId')) {
+            if (report.trackId.indexOf(localTrackIds.audio) !== -1) {
+              statsObject.audio.local.bytesSent = report.bytesSent;
+              statsObject.audio.local.codecId = report.codecId;
+              statsObject.audio.local.packetsSent = report.packetsSent;
+              statsObject.audio.local.timestamp = report.timestamp;
+              statsObject.audio.local.trackId = report.trackId;
+              statsObject.audio.local.transportId = report.transportId;
+            }
+            if (report.trackId.indexOf(localTrackIds.video) !== -1) {
+              statsObject.video.local.bytesSent = report.bytesSent;
+              statsObject.video.local.codecId = report.codecId;
+              statsObject.video.local.firCount = report.firCount;
+              statsObject.video.local.framesEncoded = report.frameEncoded;
+              statsObject.video.local.framesSent = report.framesSent;
+              statsObject.video.local.packetsSent = report.packetsSent;
+              statsObject.video.local.pliCount = report.pliCount;
+              statsObject.video.local.qpSum = report.qpSum;
+              statsObject.video.local.timestamp = report.timestamp;
+              statsObject.video.local.trackId = report.trackId;
+              statsObject.video.local.transportId = report.transportId;
+            }
+          }
+          break;
+        case 'inbound-rtp':
+          if (report.hasOwnProperty('trackId')) {
+            if(report.trackId.indexOf(remoteTrackIds.audio) !== -1) {
+              statsObject.audio.remote.bytesReceived = report.bytesReceived;
+              statsObject.audio.remote.codecId = report.codecId;
+              statsObject.audio.remote.fractionLost = report.fractionLost;
+              statsObject.audio.remote.jitter = report.jitter;
+              statsObject.audio.remote.packetsLost = report.packetsLost;
+              statsObject.audio.remote.packetsReceived = report.packetsReceived;
+              statsObject.audio.remote.timestamp = report.timestamp;
+              statsObject.audio.remote.trackId = report.trackId;
+              statsObject.audio.remote.transportId = report.transportId;
+            }
+            if (report.trackId.indexOf(remoteTrackIds.video) !== -1) {
+              statsObject.video.remote.bytesReceived = report.bytesReceived;
+              statsObject.video.remote.codecId = report.codecId;
+              statsObject.video.remote.firCount = report.firCount;
+              statsObject.video.remote.fractionLost = report.fractionLost;
+              statsObject.video.remote.nackCount = report.nackCount;
+              statsObject.video.remote.packetsLost = report.patsLost;
+              statsObject.video.remote.packetsReceived = report.packetsReceived;
+              statsObject.video.remote.pliCount = report.pliCount;
+              statsObject.video.remote.qpSum = report.qpSum;
+              statsObject.video.remote.timestamp = report.timestamp;
+              statsObject.video.remote.trackId = report.trackId;
+              statsObject.video.remote.transportId = report.transportId;
+            }
+          }
+          break;
+        case 'candidate-pair':
+          if (report.hasOwnProperty('availableOutgoingBitrate')) {
+            statsObject.connection.availableOutgoingBitrate =
+                report.availableOutgoingBitrate;
+            statsObject.connection.bytesReceived = report.bytesReceived;
+            statsObject.connection.bytesSent = report.bytesSent;
+            statsObject.connection.consentRequestsSent =
+                report.consentRequestsSent;
+            statsObject.connection.currentRoundTripTime =
+                report.currentRoundTripTime;
+            statsObject.connection.localCandidateId = report.localCandidateId;
+            statsObject.connection.remoteCandidateId = report.remoteCandidateId;
+            statsObject.connection.requestsReceived = report.requestsReceived;
+            statsObject.connection.requestsSent = report.requestsSent;
+            statsObject.connection.responsesReceived = report.responsesReceived;
+            statsObject.connection.responsesSent = report.responsesSent;
+            statsObject.connection.timestamp = report.timestamp;
+            statsObject.connection.totalRoundTripTime =
+               report.totalRoundTripTime;
+          }
+          break;
+        default:
+          return;
+      }
+    }.bind());
+
+    // Using the codec, local and remote candidate ID's to find the rest of the
+    // relevant stats.
+    stats.forEach(function(report) {
+      switch(report.type) {
+        case 'track':
+          if (report.hasOwnProperty('trackIdentifier')) {
+            if (report.trackIdentifier.indexOf(localTrackIds.video) !== -1) {
+              statsObject.video.local.frameHeight = report.frameHeight;
+              statsObject.video.local.framesSent = report.framesSent;
+              statsObject.video.local.frameWidth = report.frameWidth;
+            }
+            if (report.trackIdentifier.indexOf(remoteTrackIds.video) !== -1) {
+              statsObject.video.remote.frameHeight = report.frameHeight;
+              statsObject.video.remote.framesDecoded = report.framesDecoded;
+              statsObject.video.remote.framesDropped = report.framesDropped;
+              statsObject.video.remote.framesReceived = report.framesReceived;
+              statsObject.video.remote.frameWidth = report.frameWidth;
+            }
+            if (report.trackIdentifier.indexOf(localTrackIds.audio) !== -1) {
+              statsObject.audio.local.audioLevel = report.audioLevel ;
+            }
+            if (report.trackIdentifier.indexOf(remoteTrackIds.audio) !== -1) {
+              statsObject.audio.remote.audioLevel = report.audioLevel;
+            }
+          }
+          break;
+        case 'codec':
+          if (report.hasOwnProperty('id')) {
+            if (report.id.indexOf(statsObject.audio.local.codecId) !== -1) {
+              statsObject.audio.local.clockRate = report.clockRate;
+              statsObject.audio.local.mimeType = report.mimeType;
+              statsObject.audio.local.payloadType = report.payloadType;
+            }
+            if (report.id.indexOf(statsObject.audio.remote.codecId) !== -1) {
+              statsObject.audio.remote.clockRate = report.clockRate;
+              statsObject.audio.remote.mimeType = report.mimeType;
+              statsObject.audio.remote.payloadType = report.payloadType;
+            }
+            if (report.id.indexOf(statsObject.video.local.codecId) !== -1) {
+              statsObject.video.local.clockRate = report.clockRate;
+              statsObject.video.local.mimeType = report.mimeType;
+              statsObject.video.local.payloadType = report.payloadType;
+            }
+            if (report.id.indexOf(statsObject.video.remote.codecId) !== -1) {
+              statsObject.video.remote.clockRate = report.clockRate;
+              statsObject.video.remote.mimeType = report.mimeType;
+              statsObject.video.remote.payloadType = report.payloadType;
+            }
+          }
+          break;
+        case 'local-candidate':
+          if (report.hasOwnProperty('id')) {
+            if (report.id.indexOf(
+                statsObject.connection.localCandidateId) !== -1) {
+              statsObject.connection.localIp = report.ip;
+              statsObject.connection.localPort = report.port;
+              statsObject.connection.localPriority = report.priority;
+              statsObject.connection.localProtocol = report.protocol;
+              statsObject.connection.localType = report.candidateType;
+            }
+          }
+          break;
+        case 'remote-candidate':
+          if (report.hasOwnProperty('id')) {
+            if (report.id.indexOf(
+                statsObject.connection.remoteCandidateId) !== -1) {
+              statsObject.connection.remoteIp = report.ip;
+              statsObject.connection.remotePort = report.port;
+              statsObject.connection.remotePriority = report.priority;
+              statsObject.connection.remoteProtocol = report.protocol;
+              statsObject.connection.remoteType = report.candidateType;
+            }
+          }
+          break;
+        default:
+          return;
+      }
+    }.bind());
+  }
+  return statsObject;
 }
 
 // Takes two stats reports and determines the rate based on two counter readings

--- a/src/web_app/js/util.js
+++ b/src/web_app/js/util.js
@@ -8,7 +8,7 @@
 
 /* More information about these options at jshint.com/docs/options */
 
-/* exported setUpFullScreen, fullScreenElement, isFullScreen,
+/* exported calculateFps, setUpFullScreen, fullScreenElement, isFullScreen,
    requestIceServers, sendAsyncUrlRequest, sendSyncUrlRequest,
    randomString, trace, $, queryStringToDictionary */
 /* globals chrome */
@@ -204,6 +204,26 @@ function isChromeApp() {
   return (typeof chrome !== 'undefined' &&
           typeof chrome.storage !== 'undefined' &&
           typeof chrome.storage.local !== 'undefined');
+}
+
+// Calculcates FPS for the provided video elements and calls on a callback which
+// is used to update the necessary stats for either remote or local videos.
+// Adapted from https://cs.chromium.org/chromium/src/chrome/test/data/media/html/media_stat_perf.html
+function calculateFps(videoElement, decodedFrames, startTime, remoteOrLocal,
+  callback) {
+  var fps = 0;
+  if (videoElement &&
+      typeof videoElement.webkitDecodedFrameCount !== undefined) {
+    if (videoElement.readyState >= videoElement.HAVE_CURRENT_DATA) {
+      var currentTime = new Date().getTime();
+      var deltaTime = (currentTime - startTime) / 1000;
+      var startTimeToReturn = currentTime;
+      fps = (videoElement.webkitDecodedFrameCount - decodedFrames) / deltaTime;
+      callback(videoElement.webkitDecodedFrameCount, startTimeToReturn,
+          remoteOrLocal);
+    }
+  }
+  return parseInt(fps);
 }
 
 function trace(text) {


### PR DESCRIPTION
**Description**

- Remove unnused Callstats deps.

- Update infobox to use the new spec compliant stats and also create and internal (also useful to keep track of what stats we expect and their type) stat object mapping so we can can change underlying stats without affecting the infobox. Will look into adding Firefox support as well. 

- Calculate outgoing and incoming FPS from the video elements (necessary now since FPS is missing from the new stats).

**Purpose**

- Add new stats for video and audio.

- Fixes #452 