### PR TITLE
Fix set codec bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2664,14 +2664,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-          }
-        },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -2680,6 +2672,14 @@
             "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
           }
         },
         "stringstream": {
@@ -3183,7 +3183,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4207,11 +4207,6 @@
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -4221,6 +4216,11 @@
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -195,8 +195,15 @@ function maybeSetVideoSendInitialBitRate(sdp, params) {
     trace('Failed to find video m-line');
     return sdp;
   }
+  // Figure out the first codec payload type on the m=video SDP line.
+  var videoMLine = sdpLines[mLineIndex]
+  var pattern = new RegExp('m=video\\s\\d+\\s[A-Z\/]+\\s')
+  var sendPayloadType = videoMLine.split(pattern)[1].split(' ')[0]
+  var fmtpLine = sdpLines[findLine(sdpLines, 'a=rtpmap', sendPayloadType)]
+  var codecName = fmtpLine.split('a=rtpmap:' + sendPayloadType)[1].split('/')[0]
 
-  var codec = params.videoRecvCodec;
+  // Use codec from params if specified via URL param, otherwise use from SDP.
+  var codec = params.videoSendCodec || codecName;
   sdp = setCodecParam(sdp, codec, 'x-google-min-bitrate',
       params.videoSendInitialBitrate.toString());
   sdp = setCodecParam(sdp, codec, 'x-google-max-bitrate',
@@ -204,6 +211,7 @@ function maybeSetVideoSendInitialBitRate(sdp, params) {
 
   return sdp;
 }
+
 
 function removePayloadTypeFromMline(mLine, payloadType) {
   mLine = mLine.split(' ');

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -212,7 +212,6 @@ function maybeSetVideoSendInitialBitRate(sdp, params) {
   return sdp;
 }
 
-
 function removePayloadTypeFromMline(mLine, payloadType) {
   mLine = mLine.split(' ');
   for (var i = 0; i < mLine.length; ++i) {

--- a/src/web_app/js/sdputils.js
+++ b/src/web_app/js/sdputils.js
@@ -196,11 +196,12 @@ function maybeSetVideoSendInitialBitRate(sdp, params) {
     return sdp;
   }
   // Figure out the first codec payload type on the m=video SDP line.
-  var videoMLine = sdpLines[mLineIndex]
-  var pattern = new RegExp('m=video\\s\\d+\\s[A-Z\/]+\\s')
-  var sendPayloadType = videoMLine.split(pattern)[1].split(' ')[0]
-  var fmtpLine = sdpLines[findLine(sdpLines, 'a=rtpmap', sendPayloadType)]
-  var codecName = fmtpLine.split('a=rtpmap:' + sendPayloadType)[1].split('/')[0]
+  var videoMLine = sdpLines[mLineIndex];
+  var pattern = new RegExp('m=video\\s\\d+\\s[A-Z/]+\\s');
+  var sendPayloadType = videoMLine.split(pattern)[1].split(' ')[0];
+  var fmtpLine = sdpLines[findLine(sdpLines, 'a=rtpmap', sendPayloadType)];
+  var codecName = fmtpLine.split('a=rtpmap:' +
+      sendPayloadType)[1].split('/')[0];
 
   // Use codec from params if specified via URL param, otherwise use from SDP.
   var codec = params.videoSendCodec || codecName;


### PR DESCRIPTION
**Description**
If a user specified URL options `vsibr `and/or `vsbr `only, the default receive codec would be used (hard coded to VP9). If `vrc `was specified (video receive codec) it would be used for the send codec parameters (`fmtp`) which does not make sense (I think it was done this way since we did not support asymmetrical codecs and we had a receive codec hard coded (VP9)).

**Purpose**
Now the codec is taken from the SDP and thus the `vsibr` and `vsbr` (`x-google-min-bitrate` and `x-google-max-bitrate)` are set for the actual codec used or if the codec is specified in the `vsc` url param, it will be used.
