### PR TITLE
peerconnectionclient: use addTrack instead of addStream

### DIFF
--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -82,7 +82,9 @@ PeerConnectionClient.prototype.addStream = function(stream) {
   if (!this.pc_) {
     return;
   }
-  this.pc_.addStream(stream);
+  stream.getTracks().forEach(function(track) {
+    this.pc_.addTrack(track, stream);
+  });
 };
 
 PeerConnectionClient.prototype.startAsCaller = function(offerOptions) {

--- a/src/web_app/js/peerconnectionclient_test.js
+++ b/src/web_app/js/peerconnectionclient_test.js
@@ -35,9 +35,18 @@ describe('PeerConnectionClient Test', function() {
 
     peerConnections.push(this);
   };
+
   MockRTCPeerConnection.prototype.addStream = function(stream) {
     this.streams.push(stream);
   };
+
+  MockRTCPeerConnection.prototype.addTrack = function(track, stream) {
+    // TODO: improve mock.
+    if (this.streams.indexOf(stream) !== -1) {
+      this.streams.push(stream);
+    }
+  };
+
   MockRTCPeerConnection.prototype.createOffer = function(constraints) {
     var self = this;
     return new Promise(function(resolve, reject) {


### PR DESCRIPTION
uses addTrack instead of addStream which has been removed from the spec.
Using addTrack here would have probably (hopefully) caught
    https://bugs.chromium.org/p/chromium/issues/detail?id=762527