### PR TITLE
peerconnectionclient: (fix) undefined "this" in forEach over getTracks()

### DIFF
--- a/src/web_app/js/peerconnectionclient.js
+++ b/src/web_app/js/peerconnectionclient.js
@@ -84,7 +84,7 @@ PeerConnectionClient.prototype.addStream = function(stream) {
   }
   stream.getTracks().forEach(function(track) {
     this.pc_.addTrack(track, stream);
-  });
+  }, this);
 };
 
 PeerConnectionClient.prototype.startAsCaller = function(offerOptions) {


### PR DESCRIPTION
Hi there!

**Description**
`this` is undefined in the `forEach` loop responsible for filling PeerClient's tracks.
Indeed, as stated on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach), 

> If a thisArg parameter is provided to forEach(), it will be used as callback's this value.  Otherwise, the value undefined will be used as its this value

**Purpose**
Avoid the **TypeError** raised by trying to access the property `pc_` of **undefined** `this`.
