### PR TITLE
Fix turn override for android and iOS

### DIFF
--- a/build/ensure_gcloud_sdk_is_installed.py
+++ b/build/ensure_gcloud_sdk_is_installed.py
@@ -14,7 +14,7 @@ import subprocess
 # https://cloud.google.com/sdk/downloads#versioned
 
 GCLOUD_DOWNLOAD_URL = 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/'
-GCLOUD_SDK_TAR_FILE = 'google-cloud-sdk-138.0.0-linux-x86_64.tar.gz'
+GCLOUD_SDK_TAR_FILE = 'google-cloud-sdk-183.0.0-linux-x86_64.tar.gz'
 GCLOUD_SDK_INSTALL_FOLDER = 'google-cloud-sdk'
 TEMP_DIR = 'temp'
 GCLOUD_SDK_PATH = os.path.join(TEMP_DIR, GCLOUD_SDK_INSTALL_FOLDER)

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -42,12 +42,14 @@ def get_hd_default(user_agent):
   return 'true'
 
 # iceServers will be filled in by the TURN HTTP request.
-def make_pc_config(ice_transports):
+def make_pc_config(ice_transports, ice_server_override):
   config = {
   'iceServers': [],
   'bundlePolicy': 'max-bundle',
   'rtcpMuxPolicy': 'require'
   };
+  if ice_server_override:
+    config['iceServers'] = ice_server_override
   if ice_transports:
     config['iceTransports'] = ice_transports
   return config
@@ -260,7 +262,6 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   # TODO(tkchin): We want to provide a ICE request url on the initial get,
   # but we don't provide client_id until a join. For now just generate
   # a random id, but we should make this better.
-  # TODO(jansson): Remove this once CEOD is deprecated.
   username = client_id if client_id is not None else generate_random(9)
   if len(ice_server_base_url) > 0:
     ice_server_url = constants.ICE_SERVER_URL_TEMPLATE % \
@@ -268,14 +269,11 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   else:
     ice_server_url = ''
 
-  # TODO(jansson): Remove this once CEOD is deprecated.
-  turn_url = constants.TURN_URL_TEMPLATE % \
-      (constants.TURN_BASE_URL, username, constants.CEOD_KEY)
   # If defined it will override the ICE server provider and use the specified
   # turn servers directly.
-  turn_server_override = constants.TURN_SERVER_OVERRIDE
+  ice_server_override = constants.ICE_SERVER_OVERRIDE
 
-  pc_config = make_pc_config(ice_transports)
+  pc_config = make_pc_config(ice_transports, ice_server_override)
   pc_constraints = make_pc_constraints(dtls, dscp, ipv6)
   offer_options = {};
   media_constraints = make_media_stream_constraints(audio, video,
@@ -293,8 +291,6 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     'pc_constraints': json.dumps(pc_constraints),
     'offer_options': json.dumps(offer_options),
     'media_constraints': json.dumps(media_constraints),
-    'turn_server_override': turn_server_override,
-    'turn_url': turn_url,
     'ice_server_url': ice_server_url,
     'ice_server_transports': ice_server_transports,
     'include_loopback_js' : include_loopback_js,

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -20,10 +20,9 @@ LOOPBACK_CLIENT_ID = 'LOOPBACK_CLIENT_ID'
 
 # Turn/Stun server override. This allows AppRTC to connect to turn servers
 # directly rather than retrieving them from an ICE server provider.
-TURN_SERVER_OVERRIDE = []
+ICE_SERVER_OVERRIDE = None
 # Enable by uncomment below and comment out above, then specify turn and stun
-# servers below.
-# TURN_SERVER_OVERRIDE = [
+# ICE_SERVER_OVERRIDE  = [
 #   {
 #     "urls": [
 #       "turn:hostname/IpToTurnServer:19305?transport=udp",
@@ -38,11 +37,6 @@ TURN_SERVER_OVERRIDE = []
 #     ]
 #   }
 # ]
-
-# TODO(jansson): Remove once AppRTCDemo on iOS supports ICE_SERVER.
-TURN_BASE_URL = 'https://computeengineondemand.appspot.com'
-TURN_URL_TEMPLATE = '%s/turn?username=%s&key=%s'
-CEOD_KEY = '4080218913'
 
 ICE_SERVER_BASE_URL = 'https://networktraversal.googleapis.com'
 ICE_SERVER_URL_TEMPLATE = '%s/v1alpha/iceconfig?key=%s'

--- a/src/web_app/html/index_template.html
+++ b/src/web_app/html/index_template.html
@@ -139,18 +139,15 @@
       roomId: '{{ room_id }}',
       roomLink: '{{ room_link }}',
 {% endif %}
-
       mediaConstraints: {{ media_constraints | safe }},
       offerOptions: {{ offer_options | safe }},
       peerConnectionConfig: {{ pc_config | safe }},
       peerConnectionConstraints: {{ pc_constraints | safe }},
-      turnRequestUrl: '{{ turn_url }}',
       iceServerRequestUrl: '{{ ice_server_url }}',
       iceServerTransports: '{{ ice_server_transports }}',
       wssUrl: '{{ wss_url }}',
       wssPostUrl: '{{ wss_post_url }}',
       bypassJoinConfirmation: {{ bypass_join_confirmation }},
-      turnServerOverride: {{ turn_server_override }},
       versionInfo: {{ version_info }},
     };
 

--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -387,8 +387,8 @@ Call.prototype.maybeGetIceServers_ = function() {
   var shouldRequestIceServers =
       (this.params_.iceServerRequestUrl &&
       this.params_.iceServerRequestUrl.length > 0 &&
-      this.params_.turnServerOverride &&
-      this.params_.turnServerOverride.length === 0);
+      this.params_.peerConnectionConfig.iceServers &&
+      this.params_.peerConnectionConfig.iceServers.length === 0);
 
   var iceServerPromise = null;
   if (shouldRequestIceServers) {
@@ -414,18 +414,7 @@ Call.prototype.maybeGetIceServers_ = function() {
           trace(error.message);
         }.bind(this));
   } else {
-    if (this.params_.turnServerOverride &&
-        this.params_.turnServerOverride.length === 0) {
-      iceServerPromise = Promise.resolve();
-    } else {
-      // if turnServerOverride is not empty it will be used for
-      // turn/stun servers.
-      iceServerPromise = new Promise(function(resolve) {
-        this.params_.peerConnectionConfig.iceServers =
-            this.params_.turnServerOverride;
-        resolve();
-      }.bind(this));
-    }
+    iceServerPromise = Promise.resolve();
   }
   return iceServerPromise;
 };


### PR DESCRIPTION
**Description**
- fixes #456 (uses the fix suggested in https://github.com/webrtc/apprtc/issues/456#issuecomment-351020935)
- Remove CEOD as it's no longer used.
- Update GCLOUD version
- Rename TURN_SERVER_OVERRIDE to ICE_SERVER_OVERRIDE
- Pass in the ICE_SERVER_OVERRIDE to pc config ice servers rather than using a separate attribute for this

**Purpose**
- Reduce the amount of changes required in the clients.
