### PR TITLE
params: fix mismatched video bandwidth text

### DIFF
--- a/src/web_app/html/params.html
+++ b/src/web_app/html/params.html
@@ -83,8 +83,8 @@
         <tr><td><a href="https://appr.tc?ipv6=true">ipv6=true</a></td><td>Enable IPv6</td></tr>
         <tr><td><a href="https://appr.tc?arbr=48000">arbr=[bitrate]</a></td><td>Set audio receive bitrate, kbps</td></tr>
         <tr><td><a href="https://appr.tc?asbr=16000">asbr=[bitrate]</a></td><td>Set audio send bitrate</td></tr>
-        <tr><td><a href="https://appr.tc?vsbr=1000">vsbr=[bitrate]</a></td><td>Set video receive bitrate</td></tr>
-        <tr><td><a href="https://appr.tc?vrbr=8000">vrbr=[bitrate]</a></td><td>Set video send bitrate</td></tr>
+        <tr><td><a href="https://appr.tc?vrbr=8000">vrbr=[bitrate]</a></td><td>Set video receive bitrate</td></tr>
+        <tr><td><a href="https://appr.tc?vsbr=1000">vsbr=[bitrate]</a></td><td>Set video send bitrate</td></tr>
         <tr><td><a href="https://appr.tc?videofec=false">videofec=false</a></td><td>Turn off video FEC</td></tr>
         <tr><td><a href="https://appr.tc?opusfec=false">opusfec=false</a></td><td>Turn off Opus FEC</td></tr>
         <tr><td><a href="https://appr.tc?opusdtx=true">opusdtx=true</a></td><td>Turn on Opus DTX</td></tr>


### PR DESCRIPTION
**Description**
Fixes the mismatch between the text and the actual parameters.