### PR TITLE
Set async call cleanup as sync XHR calls are banned in Chrome

### DIFF
--- a/src/web_app/js/appcontroller.js
+++ b/src/web_app/js/appcontroller.js
@@ -220,7 +220,7 @@ AppController.prototype.finishCallSetup_ = function(roomId) {
     // clean up steps before page is closed.
     // Chrome apps can't use onbeforeunload.
     window.onbeforeunload = function() {
-      this.call_.hangup(false);
+      this.call_.hangup(true);
     }.bind(this);
 
     window.onpopstate = function(event) {

--- a/src/web_app/js/call_test.js
+++ b/src/web_app/js/call_test.js
@@ -158,7 +158,7 @@ describe('Call test', function() {
     // var realXMLHttpRequest = XMLHttpRequest;
     // XMLHttpRequest = MockXMLHttpRequest;
 
-    call.hangup(true);
+    call.hangup(false);
     // XMLHttpRequest = realXMLHttpRequest;
 
     expect(stopCalled).toBeTruthy();

--- a/src/web_app/js/call_test.js
+++ b/src/web_app/js/call_test.js
@@ -158,7 +158,7 @@ describe('Call test', function() {
     // var realXMLHttpRequest = XMLHttpRequest;
     // XMLHttpRequest = MockXMLHttpRequest;
 
-    call.hangup(false);
+    call.hangup(true);
     // XMLHttpRequest = realXMLHttpRequest;
 
     expect(stopCalled).toBeTruthy();


### PR DESCRIPTION
**Description**
Set async call cleanup as sync XHR calls are banned in Chrome

**Purpose**
Comply with web standards. If this works in downstream projects, we can remove the sync/async logic and make it async permanently.

Fixes browserstests in https://bugs.chromium.org/p/chromium/issues/detail?id=918871 hopefully.

Base is set to the updateDeps branch.