### PR TITLE
Using Forwarded header for scheme if FORWARD_SCHEME env variable is True.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Instructions were performed on Ubuntu 14.04 using Python 2.7.6 and Go 1.6.3.
 `https://[YOUR_VERSION_ID]-dot-[YOUR_PROJECT_ID]` (append `?wstls=false` to the
 URL if you have TLS disabled on Collider for dev/testing purposes).
 
+### Use Forward header scheme
+Setting environment variable ``FORWARD_SCHEME=True`` enables AppRTC to use the scheme declared in the Forwarded header ([RFC7239](https://tools.ietf.org/html/rfc7239)) so that it can be used behind a TLS terminating proxy.
+
 ## Advanced Topics
 ### Enabling Local Logging
 

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -300,7 +300,16 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
     'bypass_join_confirmation': json.dumps(bypass_join_confirmation),
     'version_info': json.dumps(get_version_info())
   }
-
+  
+  # If set to true it will take the protocol (scheme) from the http Forward
+  # header. Allows using a TLS termination proxy.
+  forward_scheme = 'FORWARD_SCHEME' in os.environ and \
+      os.environ['FORWARD_SCHEME'] == 'True'
+  if forward_scheme:
+	  forwarded = request.headers['Forwarded']
+	  forwarded = dict(item.split("=") for item in forwarded.split(";"))
+	  request.scheme = forwarded['proto']
+  
   if room_id is not None:
     room_link = request.host_url + '/r/' + room_id
     room_link = append_url_arguments(request, room_link)


### PR DESCRIPTION
**Description**
Added logic to replace request.scheme with Forwarded HTTP header ([RFC 7239](https://tools.ietf.org/html/rfc7239)) if environment variable FORWARD_SCHEME=True.

**Purpose**
Allows using Apprtc behind a TLS termination proxy. Makes Apprtc easier to deploy in a Docker environment.

**Test**
Example usage in the test development server:
`dev_appserver.py apprtc/out/app_engine --env_var FORWARD_SCHEME=True`