### PR TITLE
Update loopback.js

### DIFF
--- a/src/web_app/js/loopback.js
+++ b/src/web_app/js/loopback.js
@@ -72,6 +72,7 @@ function setupLoopback(wssUrl, roomId) {
       // https://bugs.chromium.org/p/chromium/issues/detail?id=616263
       // https://bugs.chromium.org/p/chromium/issues/detail?id=1077740
       loopbackAnswer = loopbackAnswer
+          .replace(/a=crypto:[1-9]+ .*?\\r\\n/g, '')
           .replace(/a=crypto:[1-9]+ .*/g, '');
       sendLoopbackMessage(JSON.parse(loopbackAnswer));
     } else if (message.type === 'candidate') {


### PR DESCRIPTION
**Description**
On a Mac, loopbackAnswer contains \\r\\n characters instead of proper line breaks. Because of that initial regex /a=crypto:[1-9]+ .*/g matches everything starting from a=crypto:1 and all the way to the end of loopbackAnswer, and when replaced for an empty string it corrupts the json. 

**Solution**
As a solution, I propose to first search-and-replace "mac-specific" crypto patterns (crypto all the way to first \\r\\n sequence) and only after that search-and-replace original patterns (crypto all the way to the end of the line).





