### PR TITLE
updated closure-compiler library for grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
       }
     },
 
-    closurecompiler: {
+    'closure-compiler': {
       debug: {
         files: {
           // Destination: [source files]
@@ -170,9 +170,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-csslint');
   grunt.loadNpmTasks('grunt-html');
   grunt.loadNpmTasks('grunt-shell');
-  grunt.loadNpmTasks('grunt-closurecompiler-new-grunt');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadTasks('build/grunt-chrome-build');
+  // The load-grunt-tasks plugin won't automatically load closure-compiler
+  require('google-closure-compiler').grunt(grunt);
 
   // Set default tasks to run when grunt is called without parameters.
   grunt.registerTask('default', ['runLinting', 'runPythonTests', 'build',
@@ -184,5 +185,5 @@ module.exports = function(grunt) {
                                         'shell:runPythonTests',
                                         'shell:removePythonTestsFromOutAppEngineDir']);
   grunt.registerTask('runUnitTests', ['shell:runUnitTests']),
-  grunt.registerTask('build', ['shell:buildAppEnginePackage', 'shell:genJsEnums', 'closurecompiler:debug', 'grunt-chrome-build']);
+  grunt.registerTask('build', ['shell:buildAppEnginePackage', 'shell:genJsEnums', 'closure-compiler:debug', 'grunt-chrome-build']);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,29 +464,11 @@
       "dev": true,
       "optional": true
     },
-    "bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.0.26"
-      }
-    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
       "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.1",
@@ -782,22 +764,54 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
-    "closurecompiler": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/closurecompiler/-/closurecompiler-1.6.1.tgz",
-      "integrity": "sha1-Kt3pK8jon/aHGhHPAaWeEmUKAw8=",
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "dev": true,
       "requires": {
-        "bl": "~0.9.3",
-        "closurecompiler-externs": "*",
-        "tar": "~2.2.1"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
-    },
-    "closurecompiler-externs": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/closurecompiler-externs/-/closurecompiler-externs-1.0.4.tgz",
-      "integrity": "sha1-SOoyALcKU9RoFVbEoXBt7CQlN6M=",
-      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2437,18 +2451,6 @@
         }
       }
     },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -2561,6 +2563,56 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "google-closure-compiler": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20200719.0.0.tgz",
+      "integrity": "sha512-2fZl8M6U7KTXami1joNo9e5hW88iZX1MGBSHWlDaeBqSYkvLUH2Qn/VltAQuluSRBIjPXXhxZGKHyJamVoFFnA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.x",
+        "google-closure-compiler-java": "^20200719.0.0",
+        "google-closure-compiler-js": "^20200719.0.0",
+        "google-closure-compiler-linux": "^20200719.0.0",
+        "google-closure-compiler-osx": "^20200719.0.0",
+        "google-closure-compiler-windows": "^20200719.0.0",
+        "minimist": "1.x",
+        "vinyl": "2.x",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      }
+    },
+    "google-closure-compiler-java": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20200719.0.0.tgz",
+      "integrity": "sha512-/alYc8OC9zAETZ2m10OhtqI+PAs2b8y6cLn2VlN/53dHrCC6gKqj7Ajun/GAVAUOW4HMRMnpBYdCJgMLpAniSA==",
+      "dev": true
+    },
+    "google-closure-compiler-js": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20200719.0.0.tgz",
+      "integrity": "sha512-cuowL5A4VOx9yxxMc3sSiqcj/d9aYjnHgFDvDB/dpMMOhlUMN1MDsVubuEc32tut7k/FTYFZY114CLH4r2q9/A==",
+      "dev": true
+    },
+    "google-closure-compiler-linux": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20200719.0.0.tgz",
+      "integrity": "sha512-hqPP8/7g7IMhcVle9xJ0aeiI4oRCucUGrWtQ12VwswKu2tyXTk2BDcXj5WqHae6TDPUONikQ8MCJSIENGLBC2Q==",
+      "dev": true,
+      "optional": true
+    },
+    "google-closure-compiler-osx": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20200719.0.0.tgz",
+      "integrity": "sha512-Y0RDdOAJ7CLya0pMjmLahiqh7b9aJGybKBTxPywK2CiJj1+z+EtvXN+QsaM0aSE8yvuvIbAWHOX4FjEXMRiTmw==",
+      "dev": true,
+      "optional": true
+    },
+    "google-closure-compiler-windows": {
+      "version": "20200719.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20200719.0.0.tgz",
+      "integrity": "sha512-U1onpG6RaTpRlR2nac+4GPU27LhJMr4kB4meNihwGvPRXcLh1qVcrKo+BjBuoX+Oq8KFwjc+mif3ldmv4AZzew==",
+      "dev": true,
+      "optional": true
+    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -2635,15 +2687,6 @@
             "osenv": "^0.1.4"
           }
         }
-      }
-    },
-    "grunt-closurecompiler-new-grunt": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-closurecompiler-new-grunt/-/grunt-closurecompiler-new-grunt-1.0.1.tgz",
-      "integrity": "sha1-lu3xEGLCee5uEEpuO+cJMTsrcus=",
-      "dev": true,
-      "requires": {
-        "closurecompiler": ">=1.2"
       }
     },
     "grunt-contrib-compress": {
@@ -4642,26 +4685,6 @@
         "read-pkg": "^1.0.0"
       }
     },
-    "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
-    },
     "readdirp": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
@@ -4763,6 +4786,12 @@
       "requires": {
         "is-finite": "^1.0.0"
       }
+    },
+    "replace-ext": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -5369,12 +5398,6 @@
         "strip-ansi": "^3.0.0"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -5467,17 +5490,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-      "dev": true,
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
       }
     },
     "tar-fs": {
@@ -5897,6 +5909,29 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vinyl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.1"
       }
     },
     "vnu-jar": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "devDependencies": {
     "eslint-config-webrtc": ">=1.0.0",
+    "google-closure-compiler": "^20200719.0.0",
     "grunt": "^1.0.4",
     "grunt-cli": "^1.3.2",
-    "grunt-closurecompiler-new-grunt": ">=1.0.1",
     "grunt-contrib-compress": "^1.6.0",
     "grunt-contrib-csslint": "^2.0.0",
     "grunt-eslint": "^22.0.0",


### PR DESCRIPTION
**Description**
Removed `grunt-closurecompiler-new-grunt` and added `google-closure-compiler` to fix `npm install`

**Purpose**
`npm install` in the project's root folder is failing due to `ClosureCompiler` 

Getting error:

>  Downloading https://dl.google.com/closure-compiler/compiler-latest.tar.gz ...
>   ✖ Download failed: Error: Download failed: HTTP status code 404


As per this https://github.com/google/closure-compiler/issues/3662#issuecomment-675524506 we should use Maven or NPM to install closure-compiler.
`grunt-closurecompiler-new-grunt` task uses closurecompiler, so to remove this dependency, I replaced the task with `google-closure-compiler`

Ref: https://github.com/google/closure-compiler-npm/blob/master/packages/google-closure-compiler/docs/grunt.md

https://github.com/google/closure-compiler/issues/3662