### PR TITLE
Add a way to pass the TURN server API key as a request parameter.

### DIFF
--- a/build/ensure_gcloud_sdk_is_installed.py
+++ b/build/ensure_gcloud_sdk_is_installed.py
@@ -29,6 +29,7 @@ def _Download(url, to):
   except urllib2.HTTPError, r:
     print('Could not download: %s Error: %d. %s' % (
         to, r.code, r.reason))
+    raise
 
 
 def _Extract(file_to_extract_path, destination_path):

--- a/build/ensure_gcloud_sdk_is_installed.py
+++ b/build/ensure_gcloud_sdk_is_installed.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 
 import os
-import sys
-import requests
-import tarfile
 import subprocess
+import sys
+import tarfile
+import urllib2
 
 # We are downloading a specific version of the Gcloud SDK because we have not
 # found a URL to fetch the "latest" version.
@@ -14,22 +14,21 @@ import subprocess
 # https://cloud.google.com/sdk/downloads#versioned
 
 GCLOUD_DOWNLOAD_URL = 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/'
-GCLOUD_SDK_TAR_FILE = 'google-cloud-sdk-183.0.0-linux-x86_64.tar.gz'
+GCLOUD_SDK_TAR_FILE = 'google-cloud-sdk-308.0.0-linux-x86_64.tar.gz'
 GCLOUD_SDK_INSTALL_FOLDER = 'google-cloud-sdk'
 TEMP_DIR = 'temp'
 GCLOUD_SDK_PATH = os.path.join(TEMP_DIR, GCLOUD_SDK_INSTALL_FOLDER)
 
 def _Download(url, to):
   print 'Downloading %s to %s...' % (url, to)
-  response = requests.get(url, stream=True)
-  if response.status_code == 200:
-    print 'Downloading %s to %s...' % (url, to)
-    with open(to, 'w') as to_file:
-      for chunk in response.iter_content(chunk_size=1024):
-        to_file.write(chunk)
-  else:
-    raise NameError('Could not download: %s Error: %s' % (to,
-        str(response.status_code)))
+  request = urllib2.urlopen(url)
+  try:
+    f = urllib2.urlopen(request)
+    with open(to, 'wb') as to_file:
+      to_file.write(f.read())
+  except urllib2.HTTPError, r:
+    print('Could not download: %s Error: %d. %s' % (
+        to, r.code, r.reason))
 
 
 def _Extract(file_to_extract_path, destination_path):

--- a/src/app_engine/app.yaml
+++ b/src/app_engine/app.yaml
@@ -48,7 +48,7 @@ env_variables:
   # Only change these while developing, do not commit to source!
   # Use appcfg.py --env_variable=ICE_SERVER_API_KEY:KEY \
   # in order to replace variables when deploying.
-  ICE_SERVER_API_KEY: none
+  ICE_SERVER_API_KEY: ""
   # A message that is always displayed on the app page.
   # This is useful for cases like indicating to the user that this
   # is a demo deployment of the app.

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -257,8 +257,9 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
   # a random id, but we should make this better.
   username = client_id if client_id is not None else generate_random(9)
   if len(ice_server_base_url) > 0:
+    api_key = request.get('apikey', default_value=constants.ICE_SERVER_API_KEY)
     ice_server_url = constants.ICE_SERVER_URL_TEMPLATE % \
-        (ice_server_base_url, constants.ICE_SERVER_API_KEY)
+        (ice_server_base_url, api_key)
   else:
     ice_server_url = ''
 
@@ -268,7 +269,7 @@ def get_room_parameters(request, room_id, client_id, is_initiator):
 
   pc_config = make_pc_config(ice_transports, ice_server_override)
   pc_constraints = make_pc_constraints(dtls, dscp, ipv6)
-  offer_options = {};
+  offer_options = {}
   media_constraints = make_media_stream_constraints(audio, video,
                                                     firefox_fake_device)
   wss_url, wss_post_url = get_wss_parameters(request)

--- a/src/web_app/html/params.html
+++ b/src/web_app/html/params.html
@@ -69,6 +69,7 @@
         <tr><td><a href="https://appr.tc?stereo=true&amp;audio=echoCancellation=false">stereo=true&amp;audio=echoCancellation=false</a></td><td>Turn on stereo audio</td></tr>
         <tr><td><a href="https://appr.tc?debug=loopback">debug=loopback</a></td><td>Connect to yourself, e.g. to test firewalls</td></tr>
         <tr><td><a href="https://appr.tc?ts=https://turn.example.org">ts=[turnserver]</a></td><td>Set TURN server different from the default</td></tr>
+        <tr><td><a href="https://appr.tc?apikey=example-key">apikey=[apikey]</a></td><td>Turn server API key</td></tr>
         <tr><td><a href="https://appr.tc?audio=true&amp;video=false">audio=true&amp;video=false</a></td><td>Audio only</td></tr>
         <tr><td><a href="https://appr.tc?audio=false">audio=false</a></td><td>Video only</td></tr>
         <tr><td><a href="https://appr.tc?audio=echoCancellation=false">audio=echoCancellation=false</a></td><td>Disable all audio processing</td></tr>


### PR DESCRIPTION
**Description**


**Purpose**
This allows using a different key than the one configured in app.yaml
through the new 'apikey=' parameter, just like we do with the TURN server
using the 'ts' parameter.