### PR TITLE
Also use the API key override when getting room parameters.

### DIFF
--- a/src/web_app/js/appwindow.js
+++ b/src/web_app/js/appwindow.js
@@ -22,8 +22,13 @@ var loadingParams = {
   connect: false,
   paramsFunction: function() {
     return new Promise(function(resolve, reject) {
-      trace('Initializing; retrieving params from: ' + roomServer + '/params');
-      sendAsyncUrlRequest('GET', roomServer + '/params').then(function(result) {
+      var currentUrl = new URL(document.location.href);
+      var paramsUrl = roomServer + '/params';
+      if (currentUrl.searchParams.has("apikey")) {
+        paramsUrl += '?apikey=' + currentUrl.searchParams.get("apikey");
+      }
+      trace('Initializing; retrieving params from: ' + paramsUrl);
+      sendAsyncUrlRequest('GET', paramsUrl).then(function(result) {
         var serverParams = parseJSON(result);
         var newParams = {};
         if (!serverParams) {


### PR DESCRIPTION
**Description**
This is a follow up from https://github.com/webrtc/apprtc/pull/679 where we start passing the TURN server API key in the request URL. 

**Purpose**
