### PR TITLE
Don't include loopback by default.

### DIFF
--- a/src/web_app/html/index_template.html
+++ b/src/web_app/html/index_template.html
@@ -120,7 +120,6 @@
     <a href="//github.com/webrtc/apprtc">Code repo</a>
   </div>
 
-  {{ include_loopback_js }}
   <script src="/js/adapter.js"></script>
   <script src="/js/util.js"></script>
   <script src="/js/sdputils.js"></script>
@@ -129,7 +128,7 @@
   <script src="/js/call.js"></script>
   <script src="/js/constants.js"></script>
   <script src="/js/infobox.js"></script>
-  <script src="/js/loopback.js"></script>
+  {{ include_loopback_js }}
   <script src="/js/peerconnectionclient.js"></script>
   <script src="/js/roomselection.js"></script>
   <script src="/js/signalingchannel.js"></script>


### PR DESCRIPTION
**Description**
Including `js/loopback.js` by default breaks calls with remote parties.

**Purpose**
