### PR TITLE
Add a way to provide STUN servers from AppRTC configuration directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Instructions were performed on Ubuntu 14.04 using Python 2.7.6 and Go 1.6.3.
     *  Change `WSS_INSTANCE_HOST_KEY` to the hostname and port Collider is listening too, e.g. `localhost:8089` or `otherHost:443`.
 
 ### TURN/STUN
- * **If using TURN and STUN servers directly**
+
+* **If using TURN and STUN servers directly**
+
+    Either:
+
     * Comment out `TURN_SERVER_OVERRIDE = []` and then uncomment `TURN_SERVER_OVERRIDE = [ { "urls":...]` three lines below and fill your TURN server details, e.g.
 
     ```python
@@ -72,13 +76,21 @@ Instructions were performed on Ubuntu 14.04 using Python 2.7.6 and Go 1.6.3.
     ]
     ```
 
+    * Or:
+
+    Set the the comma-separated list of STUN servers in app.yaml. e.g.
+
+    ```
+    ICE_SERVER_URLS: "stun:hostnameForYourStunServer,stun:hostnameForYourSecondStunServer"
+    ```
+
 * **Else if using ICE Server provider [1]**
   * Change `ICE_SERVER_BASE_URL` to your ICE server provider host.
   * Change `ICE_SERVER_URL_TEMPLATE` to a path or empty string depending if your ICE server provider has a specific URL path or not.
   * Change `ICE_SERVER_API_KEY` to an API key or empty string depending if your ICE server provider requires an API key to access it or not.
 
   ```python
-  ICE_SERVER_BASE_URL = 'https://networktraversal.googleapis.com'
+  ICE_SERVER_BASE_URL = 'https://appr.tc'
   ICE_SERVER_URL_TEMPLATE = '%s/v1alpha/iceconfig?key=%s'
   ICE_SERVER_API_KEY = os.environ.get('ICE_SERVER_API_KEY')
   ```

--- a/src/app_engine/app.yaml
+++ b/src/app_engine/app.yaml
@@ -49,6 +49,9 @@ env_variables:
   # Use appcfg.py --env_variable=ICE_SERVER_API_KEY:KEY \
   # in order to replace variables when deploying.
   ICE_SERVER_API_KEY: ""
+  # Comma-separated list of ICE urls to return when no ice server
+  # is specified.
+  ICE_SERVER_URLS: ""
   # A message that is always displayed on the app page.
   # This is useful for cases like indicating to the user that this
   # is a demo deployment of the app.

--- a/src/app_engine/apprtc.py
+++ b/src/app_engine/apprtc.py
@@ -594,6 +594,16 @@ def checkIfRedirect(self):
     redirect_url = constants.REDIRECT_URL + self.request.path + parsed_args
     webapp2.redirect(redirect_url, permanent=True, abort=True)
 
+class IceConfigurationPage(webapp2.RequestHandler):
+  def post(self):
+    ice_config = {}
+    if constants.ICE_SERVER_OVERRIDE:
+      ice_config = {"iceServers": constants.ICE_SERVER_OVERRIDE}
+    else:
+      ice_config = {"iceServers": [{"urls": constants.ICE_SERVER_URLS}]}
+    self.response.write(json.dumps(ice_config))
+
+
 app = webapp2.WSGIApplication([
     ('/', MainPage),
     ('/a/', analytics_page.AnalyticsPage),
@@ -602,5 +612,6 @@ app = webapp2.WSGIApplication([
     ('/leave/([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)', LeavePage),
     ('/message/([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)', MessagePage),
     ('/params', ParamsPage),
+    ('/v1alpha/iceconfig', IceConfigurationPage),
     ('/r/([a-zA-Z0-9-_]+)', RoomPage),
 ], debug=True)

--- a/src/app_engine/constants.py
+++ b/src/app_engine/constants.py
@@ -38,10 +38,11 @@ ICE_SERVER_OVERRIDE = None
 #   }
 # ]
 
-ICE_SERVER_BASE_URL = 'https://networktraversal.googleapis.com'
+ICE_SERVER_BASE_URL = 'https://appr.tc'
 ICE_SERVER_URL_TEMPLATE = '%s/v1alpha/iceconfig?key=%s'
 ICE_SERVER_API_KEY = os.environ.get('ICE_SERVER_API_KEY')
 HEADER_MESSAGE = os.environ.get('HEADER_MESSAGE')
+ICE_SERVER_URLS = [url for url in os.environ.get('ICE_SERVER_URLS', '').split(',') if url]
 
 # Dictionary keys in the collider instance info constant.
 WSS_INSTANCE_HOST_KEY = 'host_port_pair'


### PR DESCRIPTION
**Description**
Add a way to provide STUN servers from AppRTC configuration directly nstead of using a provider server or hard-coding the URLs in constants.py.

**Purpose**
Allow calls that don't need TURN credentials to still connect by using STUN