### PR TITLE
fix bug with relayProtocol === undefined && relayProtocol.toUpperCase()

### DIFF
--- a/src/web_app/js/infobox.js
+++ b/src/web_app/js/infobox.js
@@ -173,7 +173,7 @@ InfoBox.prototype.updateInfoDiv = function() {
     if (localAddr && remoteAddr) {
       var relayProtocol = connectionStats.localRelayProtocol;
       contents += this.buildLine_('LocalAddr', localAddr +
-          ' (' + localAddrType + (typeof relayProtocol !== undefined ? '' +
+          ' (' + localAddrType + (typeof relayProtocol === undefined ? '' +
           'TURN/' + relayProtocol.toUpperCase() : '') + ')');
       contents += this.buildLine_('LocalPort', localPort);
       contents += this.buildLine_('RemoteAddr', remoteAddr + ' (' +


### PR DESCRIPTION
**Description**
Runtime error: `TypeError: Cannot read property 'toUpperCase' of undefined`. 
Default value for `connectionStats.localRelayProtocol` is `undefined`.

https://github.com/webrtc/apprtc/blob/78600dbe205774c115cf481a091387d928c99d6a/src/web_app/js/stats.js#L152-L154

**Purpose**
Remove the logical `NOT` operation from the check.