### PR TITLE
Add Dockerfile for localhost non TLS docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ CMD ./start.sh
 # - Build the Dockerfile into an image: 'sudo docker build apprtc/'
 #   Note the image ID from the build command, e.g. something like 'Successfully built 503621f4f7bd'.
 # - Run: 'sudo docker run -p 8080:8080 -p 8089:8089 --rm -ti 503621f4f7bd'
-#   The container will now run in interactive mode and output logging. This can ofc be prevent if you run in 
-#   non-interactive mode. The -p are port mappings to the GAE app and Collider instances, the host ones can be changed.
+#   The container will now run in interactive mode and output logging. If you do not want this, omit the '-ti' argument.
+#   The '-p' options are port mappings to the GAE app and Collider instances, the host ones can be changed.
 #
 # - On the same machine that this docker image is running on you can now join apprtc calls using 
 #   http://localhost:8080/?wshpp=localhost:8089&wstls=false,  once you join the URL will have 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,25 +53,24 @@ RUN chmod +x start.sh
 CMD ./start.sh
 
 ## Instructions (Tested on Debian 11 only):
-# - Download the Dockerfile from the AppRTC repo and put it in a folder, e.g. apprtc
-# - Build the Dockerfile into an image: sudo docker build apprtc/
+# - Download the Dockerfile from the AppRTC repo and put it in a folder, e.g. 'apprtc'
+# - Build the Dockerfile into an image: 'sudo docker build apprtc/'
 #   Note the image ID from the build command, e.g. something like 'Successfully built 503621f4f7bd'.
-# - Run 'sudo docker run -p 8080:8080 -p 8089:8089 --rm -ti 503621f4f7bd'
-# - The container will now run in interactive mode and output logging. This can ofc be prevent if you run in 
+# - Run: 'sudo docker run -p 8080:8080 -p 8089:8089 --rm -ti 503621f4f7bd'
+#   The container will now run in interactive mode and output logging. This can ofc be prevent if you run in 
 #   non-interactive mode. The -p are port mappings to the GAE app and Collider instances, the host ones can be changed.
-
-# On the same machine that this docker image is running on you can now join apprtc calls using 
-# http://localhost:8080/?wshpp=localhost:8089&wstls=false,  once you join the URL will have 
-# appended the room name which you can share, e.g. http://localhost:8080/r/315402015?wshpp=localhost:8089&wstls=false. 
-
-# Keep in mind that you need to pass in those 'wshpp' and 'wstls' URL parameters everytime you join with as they override 
-# the websocket server address and turns off secure websockets.
-
-# NOTE that localhost is special allowing getusermedia to be accessed without TLS. If you host it on a different hostname
+#
+# - On the same machine that this docker image is running on you can now join apprtc calls using 
+#   http://localhost:8080/?wshpp=localhost:8089&wstls=false,  once you join the URL will have 
+#   appended the room name which you can share, e.g. 'http://localhost:8080/r/315402015?wshpp=localhost:8089&wstls=false'.
+#   
+#   Keep in mind that you need to pass in those 'wshpp' and 'wstls' URL parameters everytime you join with as they override 
+#   the websocket server address and turns off secure websockets.
+#
+# NOTE: that localhost is special (at least on Chrome) allowing getusermedia to be accessed without TLS. If you host it on a different hostname
 # or host alltogheter, TLS is most likely required unless you can do fancy forwarding (so that each client appears
 # to be using localhost but forwards the traffic to the machine running the docker container, not sure if this is possible).
-
-# NOTE it is possible to run docker without sudo but requires extra setup to do so.
+# The steps assume sudo is required for docker, that can be avoided but is out of scope.
 
 ## TODO
 # Investigate if TLS support can be added using self signed certificates. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+#######DEMO APP, DO NOT USE THIS FOR ANYTHING BUT TESTING PURPOSES, ITS NOT MEANT FOR PRODUCTION######
+
+FROM golang:1.17.5-alpine3.15
+
+# Install and download deps.
+RUN apk add --no-cache git curl python2
+RUN git clone https://github.com/webrtc/apprtc.git
+
+# AppRTC GAE setup
+
+# Required to run GAE dev_appserver.py.
+RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-367.0.0-linux-x86_64.tar.gz --output gcloud.tar.gz
+RUN tar -xf gcloud.tar.gz
+RUN google-cloud-sdk/bin/gcloud components install app-engine-python-extras app-engine-python cloud-datastore-emulator --quiet
+
+# Mimick build step by manually copying everything into the appropriate folder and run build script.
+WORKDIR apprtc
+RUN python build/build_app_engine_package.py src/ out/
+RUN curl https://webrtc.github.io/adapter/adapter-latest.js --output src/web_app/js/adapter.js
+RUN cp src/web_app/js/*.js out/js/
+
+# Wrap AppRTC GAE app in a bash script due to needing to run two apps within one container.
+# Make sure we are in the /go/ root folder.
+WORKDIR ../
+RUN echo -e "#!/bin/sh\n" > start.sh
+RUN echo -e "`pwd`/google-cloud-sdk/bin/dev_appserver.py --host 0.0.0.0 `pwd`/apprtc/out/app.yaml &\n" >> start.sh
+
+# Collider setup
+
+# Go environment setup.
+RUN export GOPATH=$HOME/goWorkspace/
+RUN go env -w GO111MODULE=off
+RUN  ln -s `pwd`/apprtc/src/collider/collidermain $GOPATH/src
+RUN  ln -s `pwd`/apprtc/src/collider/collidertest $GOPATH/src
+RUN  ln -s `pwd`/apprtc/src/collider/collider $GOPATH/src
+WORKDIR $GOPATH/src
+
+# Download all the dependencies
+RUN go get collidermain
+
+# Install the package
+RUN go install collidermain
+
+# Add Collider executable to the start.sh bash script.
+WORKDIR ../
+RUN echo -e "$GOPATH/bin/collidermain -port=8089 -tls=false -room-server=http://localhost &\n" >> start.sh
+RUN echo -e "wait -n\n" >> start.sh
+RUN echo -e "exit $?\n" >> start.sh
+# Make it executable.
+RUN chmod +x start.sh
+
+# Start the bash wrapper that keeps both collider and the AppRTC GAE app running. 
+CMD ./start.sh
+
+## Instructions (Tested on Debian 11 only):
+# - Download the Dockerfile from the AppRTC repo and put it in a folder, e.g. apprtc
+# - Build the Dockerfile into an image: sudo docker build apprtc/
+#   Note the image ID from the build command, e.g. something like 'Successfully built 503621f4f7bd'.
+# - Run 'sudo docker run -p 8080:8080 -p 8089:8089 --rm -ti 503621f4f7bd'
+# - The container will now run in interactive mode and output logging. This can ofc be prevent if you run in 
+#   non-interactive mode. The -p are port mappings to the GAE app and Collider instances, the host ones can be changed.
+
+# On the same machine that this docker image is running on you can now join apprtc calls using 
+# http://localhost:8080/?wshpp=localhost:8089&wstls=false,  once you join the URL will have 
+# appended the room name which you can share, e.g. http://localhost:8080/r/315402015?wshpp=localhost:8089&wstls=false. 
+
+# Keep in mind that you need to pass in those 'wshpp' and 'wstls' URL parameters everytime you join with as they override 
+# the websocket server address and turns off secure websockets.
+
+# NOTE that localhost is special allowing getusermedia to be accessed without TLS. If you host it on a different hostname
+# or host alltogheter, TLS is most likely required unless you can do fancy forwarding (so that each client appears
+# to be using localhost but forwards the traffic to the machine running the docker container, not sure if this is possible).
+
+# NOTE it is possible to run docker without sudo but requires extra setup to do so.
+
+## TODO
+# Investigate if TLS support can be added using self signed certificates. 
+# Verify if this docker container run on more OS's?
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ RUN echo -e "#!/bin/sh\n" > /go/start.sh \
     && echo -e "`pwd`/google-cloud-sdk/bin/dev_appserver.py --host 0.0.0.0 `pwd`/apprtc/out/app.yaml &\n" >> /go/start.sh
 
 # Collider setup
-
+# Go environment setup.
 RUN export GOPATH=$HOME/goWorkspace/ \
     && go env -w GO111MODULE=off
-# Go environment setup.
+
 RUN ln -s `pwd`/apprtc/src/collider/collidermain $GOPATH/src \
     && ln -s `pwd`/apprtc/src/collider/collidertest $GOPATH/src \
     && ln -s `pwd`/apprtc/src/collider/collider $GOPATH/src \


### PR DESCRIPTION
**Description**
Sets up a localhost non TLS capable AppRTC instance with Collider

I've made it the way it is to keep everything contained inside the Dockerfile without requiring other scripts etc (hence why the start.sh script is generated within the Dockerfile).

**Purpose**
Allow local development and testing using AppRTC locally

NOTE: Any docker specialist please chime in, I'm quite the noob in dockerverse